### PR TITLE
ci: removed contributors gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,25 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  contributors:
-    runs-on: ubuntu-latest
-    name: Contributors
-    steps:
-      - name: Doc contributors
-        uses: akhilmhdh/contributors-readme-action@v2.3.6
-        if: github.event_name == 'push'
-        with:
-          image_size: 50
-          readme_path: 'documentation/contributing/Contributors.md'
-          columns_per_row: 8
-          use_username: true
-          commit_message: 'docs(chore): update contributors'
-          committer_username: 'github-actions[bot]'
-          committer_email: 'github-actions[bot]@users.noreply.github.com'
-          auto_detect_branch_protection: false
-          collaborators: 'outside'
-        env:
-          GITHUB_TOKEN: ${{ secrets.SA_TOKEN }}
   release:
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +29,7 @@ jobs:
       - name: Publish
         run: npm run release
   deploy:
-    needs: [contributors, release]
+    needs: [release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description, Motivation and Context

Removed automation of Contributors.md through a GH Action (broken after repo transfer)

### Types of changes

- [x] 🛠️ Tool
