### PR TITLE
chore: removed former spark members from dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-- @kikoruiz @andresin87 @andresz1 @turolopezsanabria @thomas-leguellec @victorsolajurnet @Powerplex @acd02 @solygambas @soykje
+- @Powerplex @acd02 @soykje
 
 # Order is important. The last matching pattern has the most precedence.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
       interval: 'weekly'
     reviewers:
       - 'acd02'
-      - 'andresin87'
-      - 'andresz1'
-      - 'kikoruiz'
       - 'Powerplex'
       - 'soykje'
     ignore:


### PR DESCRIPTION
### Description, Motivation and Context

Some people belonged to `adevinta` org, and the repo has been transfered to `leboncoin`.

In order to avoid error messages in the dependabot PRs, I must remove them from the list (they could be re-added later by joining the `leboncoin` org)

### Types of changes

- [x] 🛠️ Tool

