### PR TITLE
chore: removed usage of glob package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15460,6 +15460,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -15953,23 +15954,6 @@
         "ini": "^1.3.2"
       }
     },
-    "node_modules/glob": {
-      "version": "8.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "license": "ISC",
@@ -15978,23 +15962,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/global-directory": {
@@ -16613,6 +16580,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -16621,6 +16589,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -21797,6 +21766,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -27256,6 +27226,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -28406,7 +28377,6 @@
         "commander": "10.0.1",
         "esbuild": "0.25.1",
         "fs-extra": "11.3.0",
-        "glob": "8.1.0",
         "pascal-case": "3.1.2",
         "ts-morph": "22.0.0"
       },

--- a/packages/utils/cli/package.json
+++ b/packages/utils/cli/package.json
@@ -38,7 +38,6 @@
     "commander": "10.0.1",
     "esbuild": "0.25.1",
     "fs-extra": "11.3.0",
-    "glob": "8.1.0",
     "pascal-case": "3.1.2",
     "ts-morph": "22.0.0"
   },

--- a/packages/utils/cli/src/generate/generators/TemplateGenerator.mjs
+++ b/packages/utils/cli/src/generate/generators/TemplateGenerator.mjs
@@ -1,7 +1,8 @@
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { camelCase } from 'camel-case'
-import glob from 'glob'
 import { pascalCase } from 'pascal-case'
 
 import { Generator } from './Generator.mjs'
@@ -32,18 +33,11 @@ export class TemplateGenerator extends Generator {
     return `${basePath}/packages/${context}/${name}`
   }
 
-  getTemplatePaths({ type }) {
-    const pattern = fileURLToPath(new URL(`../templates/${type}/**/*.js`, import.meta.url))
+  async getTemplatePaths({ type }) {
+    const templateDir = fileURLToPath(new URL(`../templates/${type}`, import.meta.url))
+    const files = await readdir(templateDir, { recursive: true })
 
-    return new Promise((resolve, reject) => {
-      glob(pattern, async (error, paths) => {
-        if (error) {
-          return reject(error)
-        }
-
-        resolve(paths)
-      })
-    })
+    return files.filter(file => file.endsWith('.js')).map(file => join(templateDir, file))
   }
 
   getTemplatePath({ path, name, type, dest }) {


### PR DESCRIPTION
### Description, Motivation and Context

`glob` package was used in only two files, for internal usage in Spark to generate new packages. It was 3 major versions late and updating it breaks things, I prefer to get rid of it for now.

### Types of changes
- [x] 🧠 Refactor
