### PR TITLE
ci: dependabot will no longer ignore major versions of deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,31 @@ updates:
     schedule:
       interval: 'weekly'
     reviewers:
-      - 'acd02'
       - 'Powerplex'
-      - 'soykje'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@storybook/*'
-      - dependency-name: 'storybook'
     commit-message:
       prefix: 'build(npm)'
+    groups:
+      zag-js:
+        patterns:
+          - '@zag-js/*'
+      testing:
+        patterns:
+          - '@testing-library/*'
+          - '@testing-library'
+          - 'vitest'
+          - '@vitest/*'
+          - '@vitest'
+          - '@playwright/*'
+          - '@playwright'
+      storybook:
+        patterns:
+          - '@storybook/*'
+          - '*storybook*'
+      vite:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - '*vite*'
+      dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
### Description, Motivation and Context

Fine-tuned dependabot settings:
- grouping weekly updates in a single PR.
- only assigning @Powerplex as reviewer (core maintainer going forward).
- **no longers ignores major updates**

### Types of changes
- [x] 🛠️ Tool
