### PR TITLE
fix: form-field context in input components was lost after build

### DIFF
--- a/packages/components/src/checkbox/Checkbox.tsx
+++ b/packages/components/src/checkbox/Checkbox.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
 import { Ref, useId, useMemo, useRef } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { CheckboxGroupContextState, useCheckboxGroup } from './CheckboxGroupContext'
 import { CheckboxInput, CheckboxInputProps } from './CheckboxInput'
 import { CheckboxLabel } from './CheckboxLabel'

--- a/packages/components/src/checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/checkbox/CheckboxGroup.tsx
@@ -1,7 +1,7 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import { ComponentPropsWithoutRef, Ref, useEffect, useMemo, useRef } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { checkboxGroupStyles, CheckboxGroupStylesProps } from './CheckboxGroup.styles'
 import { CheckboxGroupContext, CheckboxGroupContextState } from './CheckboxGroupContext'
 

--- a/packages/components/src/combobox/ComboboxContext.tsx
+++ b/packages/components/src/combobox/ComboboxContext.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 /* eslint-disable max-lines-per-function */
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import { useCombobox, useMultipleSelection } from 'downshift'
 import {
@@ -16,7 +17,6 @@ import {
   useState,
 } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { Popover } from '../popover'
 import { type ComboboxItem, type DownshiftState, type ItemsMap } from './types'
 import { multipleSelectionReducer } from './useCombobox/multipleSelectionReducer'

--- a/packages/components/src/combobox/ComboboxTrigger.tsx
+++ b/packages/components/src/combobox/ComboboxTrigger.tsx
@@ -1,8 +1,8 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
 import { Fragment, ReactNode, Ref, useEffect, useRef } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { Popover } from '../popover'
 import { useComboboxContext } from './ComboboxContext'
 import { styles } from './ComboboxTrigger.styles'

--- a/packages/components/src/dropdown/DropdownContext.tsx
+++ b/packages/components/src/dropdown/DropdownContext.tsx
@@ -1,3 +1,4 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import {
   createContext,
   Dispatch,
@@ -10,7 +11,6 @@ import {
   useState,
 } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { Popover } from '../popover'
 import { type DownshiftState, type DropdownItem, type ItemsMap } from './types'
 import { useDropdown } from './useDropdown'

--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -1,6 +1,6 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { ChangeEventHandler, ComponentPropsWithoutRef, KeyboardEventHandler, Ref } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { Slot } from '../slot'
 import { inputStyles } from './Input.styles'
 import { useInputGroup } from './InputGroupContext'

--- a/packages/components/src/input/InputGroup.tsx
+++ b/packages/components/src/input/InputGroup.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import {
@@ -19,7 +20,6 @@ import {
   useRef,
 } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { InputProps } from './Input'
 import { inputGroupStyles, InputGroupStylesProps } from './InputGroup.styles'
 import { InputGroupContext } from './InputGroupContext'

--- a/packages/components/src/radio-group/RadioGroup.tsx
+++ b/packages/components/src/radio-group/RadioGroup.tsx
@@ -1,7 +1,7 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { RadioGroup as RadixRadioGroup } from 'radix-ui'
 import { HTMLAttributes, Ref } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { radioGroupStyles, RadioGroupVariantsProps } from './RadioGroup.styles'
 import { RadioGroupProvider } from './RadioGroupProvider'
 import { RadioInputVariantsProps } from './RadioInput.styles'

--- a/packages/components/src/radio-group/RadioInput.tsx
+++ b/packages/components/src/radio-group/RadioInput.tsx
@@ -1,7 +1,7 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { RadioGroup as RadixRadioGroup } from 'radix-ui'
 import { ButtonHTMLAttributes, Ref } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { RadioIndicator } from './RadioIndicator'
 import { radioInputVariants, RadioInputVariantsProps } from './RadioInput.styles'
 

--- a/packages/components/src/select/SelectContext.tsx
+++ b/packages/components/src/select/SelectContext.tsx
@@ -1,3 +1,4 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import {
   createContext,
@@ -11,7 +12,6 @@ import {
   useState,
 } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { type ItemsMap, SelectItem } from './types'
 import { getItemsFromChildren } from './utils'
 

--- a/packages/components/src/stepper/Stepper.tsx
+++ b/packages/components/src/stepper/Stepper.tsx
@@ -1,6 +1,6 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { createContext, type PropsWithChildren, RefObject, useContext, useRef } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { InputGroup } from '../input'
 import type { StepperProps, UseStepperReturn } from './types'
 import { useStepper } from './useStepper'

--- a/packages/components/src/switch/Switch.tsx
+++ b/packages/components/src/switch/Switch.tsx
@@ -1,7 +1,7 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { cx } from 'class-variance-authority'
 import { useId } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { SwitchInput, SwitchInputProps } from './SwitchInput'
 import { SwitchLabel } from './SwitchLabel'
 

--- a/packages/components/src/switch/SwitchInput.tsx
+++ b/packages/components/src/switch/SwitchInput.tsx
@@ -1,10 +1,10 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { Check } from '@spark-ui/icons/Check'
 import { Close } from '@spark-ui/icons/Close'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import { Switch as RadixSwitch } from 'radix-ui'
 import { type ComponentPropsWithRef, type ReactNode } from 'react'
 
-import { useFormFieldControl } from '../form-field'
 import { Slot } from '../slot'
 import {
   styles,


### PR DESCRIPTION
### Description, Motivation and Context

Relative path to sibling components must not be used as it can mess with react context instances.

`form-field` context was not working correctly in `radio-group` after a build (locally it was working fine because it could resolve the relative path)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
