### PR TITLE
fix: isolate form-field code to be shared across components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,6 +4,16 @@
   "license": "MIT",
   "description": "Spark (Leboncoin design system) components.",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./form-field": {
+      "types": "./dist/form-field/index.d.ts",
+      "import": "./dist/form-field/index.mjs",
+      "require": "./dist/form-field/index.js"
+    },
     "./*": {
       "types": "./dist/*/index.d.ts",
       "import": "./dist/*/index.mjs",

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig(() => {
     format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
-    external: ['react'],
+    external: ['react', '@spark-ui/components/form-field'],
+    noExternal: ['!@spark-ui/components/form-field'],
   }
 })


### PR DESCRIPTION
### Description, Motivation and Context

Isolate the code of `form-field` during the build so it is not repeated in every component `dist`

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
