### PR TITLE
fix(components): fixed accessible description on combobox input

### DIFF
--- a/packages/components/src/combobox/ComboboxInput.tsx
+++ b/packages/components/src/combobox/ComboboxInput.tsx
@@ -1,3 +1,4 @@
+import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/use-combined-state'
 import { useMergeRefs } from '@spark-ui/use-merge-refs'
 import { cx } from 'class-variance-authority'
@@ -36,7 +37,10 @@ export const Input = ({
   ...props
 }: InputProps) => {
   const ctx = useComboboxContext()
+  const field = useFormFieldControl()
   const [inputValue] = useCombinedState(value, defaultValue)
+
+  const { isInvalid, isRequired, description } = field
 
   useEffect(() => {
     if (inputValue != null) {
@@ -130,6 +134,10 @@ export const Input = ({
           aria-label={ariaLabel}
           disabled={ctx.disabled}
           readOnly={ctx.readOnly}
+          // FormField
+          aria-invalid={isInvalid}
+          required={isRequired}
+          aria-describedby={description}
         />
       </PopoverTrigger>
     </>

--- a/packages/components/src/combobox/tests/withFormField.test.tsx
+++ b/packages/components/src/combobox/tests/withFormField.test.tsx
@@ -10,7 +10,7 @@ describe('Combobox', () => {
   describe('with FormField', () => {
     it('should render error message when field is in error', () => {
       render(
-        <FormField state="error">
+        <FormField state="error" isRequired>
           <FormField.Label>Book</FormField.Label>
           <Combobox>
             <Combobox.Trigger>
@@ -28,9 +28,11 @@ describe('Combobox', () => {
         </FormField>
       )
 
-      expect(getInput('Book')).toBeInTheDocument()
+      const input = getInput('Book')
 
-      expect(screen.getByText('You forgot to select a book')).toBeInTheDocument()
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      expect(input).toHaveAttribute('required')
+      expect(input).toHaveAccessibleDescription('You forgot to select a book')
     })
 
     it('should move focus to the input field when the corresponding label is clicked', async () => {

--- a/packages/components/src/form-field/FormField.test.tsx
+++ b/packages/components/src/form-field/FormField.test.tsx
@@ -180,7 +180,6 @@ describe('FormField error message', () => {
 
     expect(inputEl).toHaveAttribute('aria-invalid', 'true')
     expect(inputEl).toHaveAttribute('aria-describedby', errorTextEl.getAttribute('id'))
-    expect(errorTextEl).toHaveAttribute('aria-live', 'polite')
   })
 
   it('should render error and helper message when is invalid', () => {

--- a/packages/components/src/form-field/FormFieldStateMessage.tsx
+++ b/packages/components/src/form-field/FormFieldStateMessage.tsx
@@ -30,7 +30,6 @@ export const FormFieldStateMessage = ({
     <FormFieldMessage
       ref={ref}
       data-spark-component="form-field-state-message"
-      aria-live="polite"
       className={cx(
         'gap-sm flex items-center',
         state === 'error' ? 'text-error' : 'text-on-surface/dim-1',


### PR DESCRIPTION
<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [SPA-598](https://jira.ets.mpi-internal.com/browse/SPA-598)

### Description, Motivation and Context

The input of the combobox is a custom one, not using `@spark-ui/input`.

`@spark-ui/input` is using the `FormField` context through `useFormFieldControl` to be linked properly to it's label/messages.

We forgot to use this hook in `Combobox.Input`.

**note**: also removes the `aria-live="polite"` from all `FormField` messages, as it is bad for a11y to read out loud message updates.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
