### PR TITLE
fix(components): removed inherited form-field require attr from combobox

### DIFF
--- a/packages/components/src/combobox/ComboboxInput.tsx
+++ b/packages/components/src/combobox/ComboboxInput.tsx
@@ -40,7 +40,7 @@ export const Input = ({
   const field = useFormFieldControl()
   const [inputValue] = useCombinedState(value, defaultValue)
 
-  const { isInvalid, isRequired, description } = field
+  const { isInvalid, description } = field
 
   useEffect(() => {
     if (inputValue != null) {
@@ -136,7 +136,6 @@ export const Input = ({
           readOnly={ctx.readOnly}
           // FormField
           aria-invalid={isInvalid}
-          required={isRequired}
           aria-describedby={description}
         />
       </PopoverTrigger>

--- a/packages/components/src/combobox/tests/withFormField.test.tsx
+++ b/packages/components/src/combobox/tests/withFormField.test.tsx
@@ -10,7 +10,7 @@ describe('Combobox', () => {
   describe('with FormField', () => {
     it('should render error message when field is in error', () => {
       render(
-        <FormField state="error" isRequired>
+        <FormField state="error">
           <FormField.Label>Book</FormField.Label>
           <Combobox>
             <Combobox.Trigger>
@@ -31,7 +31,6 @@ describe('Combobox', () => {
       const input = getInput('Book')
 
       expect(input).toHaveAttribute('aria-invalid', 'true')
-      expect(input).toHaveAttribute('required')
       expect(input).toHaveAccessibleDescription('You forgot to select a book')
     })
 


### PR DESCRIPTION
### Description, Motivation and Context

Combobox is an hybrid between an input and a dropdown and the required attr prevents form submission in some cases. Needs more time to investigate.

This attribute was added in `@spark-ui/components@10.0.5` and will be removed for now until I find a cleaner way to manage it.


### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
