### PR TITLE
feat(components): avatar component

### DIFF
--- a/documentation/helpers/A11yReport/index.tsx
+++ b/documentation/helpers/A11yReport/index.tsx
@@ -35,7 +35,7 @@ export const A11yReport = ({ of }: { of: string }) => {
   if (errors === 404) {
     return (
       <Callout kind="error" marginY="large">
-        <p>No accessibility report were find for this component.</p>
+        <p>No accessibility report were found for this component.</p>
       </Callout>
     )
   }

--- a/packages/components/src/avatar/Avatar.tsx
+++ b/packages/components/src/avatar/Avatar.tsx
@@ -1,0 +1,63 @@
+import { cx } from 'class-variance-authority'
+import * as React from 'react'
+
+import { Slot } from '../slot'
+import { AvatarContext } from './context'
+import type { AvatarProps } from './types'
+
+const sizeMap = {
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 56,
+  xl: 64, // default
+  '2xl': 96,
+}
+
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
+  (
+    {
+      className,
+      size = 'xl',
+      isOnline = false,
+      onlineText,
+      username,
+      asChild,
+      children,
+      design = 'circle',
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : 'div'
+    const contextValue = React.useMemo(
+      () => ({
+        size,
+        isOnline,
+        onlineText,
+        username,
+        design,
+        pixelSize: sizeMap[size],
+      }),
+      [size, isOnline, username, design, onlineText]
+    )
+
+    return (
+      <AvatarContext.Provider value={contextValue}>
+        <Comp
+          ref={ref}
+          style={{
+            width: sizeMap[size],
+            height: sizeMap[size],
+          }}
+          className={cx('relative inline-flex items-center justify-center', className)}
+          {...props}
+        >
+          {children}
+        </Comp>
+      </AvatarContext.Provider>
+    )
+  }
+)
+
+Avatar.displayName = 'Avatar'

--- a/packages/components/src/avatar/AvatarAction.tsx
+++ b/packages/components/src/avatar/AvatarAction.tsx
@@ -1,0 +1,69 @@
+import { PenOutline } from '@spark-ui/icons/PenOutline'
+import { cx } from 'class-variance-authority'
+
+import { Icon } from '../icon'
+import { IconButton } from '../icon-button'
+import { Slot } from '../slot'
+import { useAvatarContext } from './context'
+
+export interface AvatarActionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean
+  angle?: number
+  ariaLabel: string
+}
+
+export const AvatarAction = ({
+  className,
+  children,
+  asChild,
+  angle = 135,
+  ariaLabel,
+  ...props
+}: AvatarActionProps) => {
+  const Comp = asChild ? Slot : IconButton
+  const { pixelSize, design } = useAvatarContext()
+
+  function getBadgePosition(circleSize: number) {
+    const angleRad = ((90 - angle) * Math.PI) / 180
+    const circleRadius = circleSize / 2
+
+    return {
+      x: circleRadius + circleRadius * Math.cos(angleRad),
+      y: circleRadius - circleRadius * Math.sin(angleRad),
+    }
+  }
+
+  const position = getBadgePosition(pixelSize)
+
+  const isCustomElement = asChild
+
+  return (
+    <Comp
+      style={{
+        position: 'absolute',
+        ...(design === 'circle' ? { left: `${position.x}px`, top: `${position.y}px` } : {}),
+        ...(design === 'square' ? { right: '0px', bottom: '0px' } : {}),
+      }}
+      className={cx(
+        'z-raised',
+        design === 'circle'
+          ? '-translate-x-1/2 -translate-y-1/2'
+          : 'translate-x-1/4 translate-y-1/4',
+        // { 'shadow-sm': !isCustomElement },
+        className
+      )}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      {...(!isCustomElement ? { size: 'sm', intent: 'support', design: 'tinted' } : {})}
+      {...props}
+    >
+      {children || (
+        <Icon size="sm">
+          <PenOutline />
+        </Icon>
+      )}
+    </Comp>
+  )
+}
+
+AvatarAction.displayName = 'AvatarAction'

--- a/packages/components/src/avatar/AvatarImage.tsx
+++ b/packages/components/src/avatar/AvatarImage.tsx
@@ -1,0 +1,37 @@
+import { cx } from 'class-variance-authority'
+import { useState } from 'react'
+
+import { Slot } from '../slot'
+import { useAvatarContext } from './context'
+
+export interface AvatarImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  asChild?: boolean
+}
+
+export const AvatarImage = ({ className, asChild, src, ...props }: AvatarImageProps) => {
+  const { username } = useAvatarContext()
+  const Comp = asChild ? Slot : 'img'
+
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <Comp
+      className={cx(
+        'absolute inset-0 size-full',
+        'object-cover',
+        { 'transition-all duration-300 group-hover:scale-120': props.onClick },
+        'focus-visible:u-outline',
+        isVisible ? 'block' : 'hidden',
+        className
+      )}
+      alt={username}
+      src={src}
+      onLoad={() => {
+        setIsVisible(true)
+      }}
+      {...props}
+    />
+  )
+}
+
+AvatarImage.displayName = 'AvatarImage'

--- a/packages/components/src/avatar/AvatarOnlineBadge.tsx
+++ b/packages/components/src/avatar/AvatarOnlineBadge.tsx
@@ -1,0 +1,50 @@
+import { cx } from 'class-variance-authority'
+
+import { Badge, BadgeProps } from '../badge'
+import { useAvatarContext } from './context'
+
+interface AvatarOnlineBadgeProps extends BadgeProps {
+  angle?: number
+}
+
+export const AvatarOnlineBadge = ({ angle = 135, ...props }: AvatarOnlineBadgeProps) => {
+  const { isOnline, pixelSize, design, onlineText, size } = useAvatarContext()
+
+  if (!isOnline) return null
+
+  function getBadgePosition(circleSize: number) {
+    const angleRad = ((90 - angle) * Math.PI) / 180
+    const circleRadius = circleSize / 2
+
+    return {
+      x: circleRadius + circleRadius * Math.cos(angleRad),
+      y: circleRadius - circleRadius * Math.sin(angleRad),
+    }
+  }
+
+  const badgePosition = getBadgePosition(pixelSize)
+  const badgeSize = ['lg', 'xl', '2xl'].includes(size) ? 'md' : 'sm'
+
+  return (
+    <Badge
+      role="status"
+      aria-label={onlineText}
+      size={badgeSize}
+      intent="success"
+      style={{
+        ...(design === 'circle'
+          ? { left: `${badgePosition.x}px`, top: `${badgePosition.y}px` }
+          : { right: '0px', bottom: '0px' }),
+      }}
+      className={cx(
+        'absolute',
+        design === 'circle'
+          ? '-translate-x-1/2 -translate-y-1/2'
+          : 'translate-x-1/4 translate-y-1/4'
+      )}
+      {...props}
+    />
+  )
+}
+
+AvatarOnlineBadge.displayName = 'AvatarOnlineBadge'

--- a/packages/components/src/avatar/AvatarPlaceholder.tsx
+++ b/packages/components/src/avatar/AvatarPlaceholder.tsx
@@ -1,0 +1,36 @@
+import { cx } from 'class-variance-authority'
+
+import { useAvatarContext } from './context'
+
+export interface AvatarPlaceholderProps extends React.ImgHTMLAttributes<HTMLDivElement> {
+  className?: string
+  children?: React.ReactNode
+}
+
+export const AvatarPlaceholder = ({ className, children, ...props }: AvatarPlaceholderProps) => {
+  const { size, username } = useAvatarContext()
+
+  const firstLetter = username?.charAt(0)
+
+  return (
+    <div
+      className={cx(
+        'absolute inset-0 flex size-full items-center justify-center',
+        'default:bg-neutral default:text-on-neutral',
+        {
+          'text-display-1': size === '2xl',
+          'text-display-2': ['xl', 'lg'].includes(size),
+          'text-display-3': size === 'md',
+          'text-headline-2': size === 'sm',
+          'text-body-2 font-bold': size === 'xs',
+        },
+        className
+      )}
+      {...props}
+    >
+      {children || firstLetter}
+    </div>
+  )
+}
+
+AvatarPlaceholder.displayName = 'AvatarPlaceholder'

--- a/packages/components/src/avatar/AvatarUser.tsx
+++ b/packages/components/src/avatar/AvatarUser.tsx
@@ -1,0 +1,36 @@
+import { cx } from 'class-variance-authority'
+
+import { Slot } from '../slot'
+import { useAvatarContext } from './context'
+
+export interface AvatarImageProps extends React.ImgHTMLAttributes<HTMLDivElement> {
+  asChild?: boolean
+}
+
+export const AvatarUser = ({ asChild, children, ...props }: AvatarImageProps) => {
+  const { design, isOnline, onlineText, username } = useAvatarContext()
+  const Comp = asChild ? Slot : 'div'
+
+  const accessibleName = isOnline && onlineText ? `${username} (${onlineText})` : username
+
+  return (
+    <Comp
+      aria-label={accessibleName}
+      title={accessibleName}
+      className={cx(
+        'group border-outline relative size-full overflow-hidden',
+        'focus-visible:u-outline',
+        {
+          'default:rounded-full': design === 'circle',
+          'border-md default:rounded-md': design === 'square',
+          'hover:opacity-dim-1 cursor-pointer': asChild || props.onClick,
+        }
+      )}
+      {...props}
+    >
+      {children}
+    </Comp>
+  )
+}
+
+AvatarUser.displayName = 'AvatarUser'

--- a/packages/components/src/avatar/avatar.doc.mdx
+++ b/packages/components/src/avatar/avatar.doc.mdx
@@ -1,0 +1,122 @@
+import { Meta, Canvas } from '@storybook/blocks'
+import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { A11yReport } from '@docs/helpers/A11yReport'
+import { Avatar } from '.'
+import * as stories from './avatar.stories'
+
+<Meta of={stories} />
+
+# Avatar
+
+The Avatar component displays a circular profile image with an optional online status badge and a customizable edit button.
+
+<Canvas of={stories.Default} />
+
+## Install
+
+```sh
+npm install @spark-ui/components
+```
+
+## Anatomy
+
+```tsx
+import { Avatar } from '@spark-ui/components/avatar'
+
+export default () => (
+  <Avatar>
+    <Avatar.User>
+      <Avatar.Image />
+    </Avatar.User>
+    <Avatar.Action />
+    <Avatar.OnlineBadge />
+  </Avatar>
+);
+```
+
+## Examples
+
+### Action
+
+Use the `Avatar.Action` component to display an action button on the avatar.
+
+Use `children` to use a custom icon.
+
+Use the `asChild` prop to replace with a custom element.
+
+We advise using Avatar.Action with the lg and above sizes.
+
+<Canvas of={stories.Actions} />
+
+### As a link
+
+Use the `asChild` on `Avatar.User` prop to turn into a link (or a button).
+
+<Canvas of={stories.AsLink} />
+
+### Online Status
+
+Use the `isOnline` prop to display a badge indicating this user is online.
+
+<Canvas of={stories.WithOnlineStatus} />
+
+### Placeholder
+
+Use the `Avatar.Placeholder` to display a placeholder avatar.
+
+By default it will use the first letter of the username, but you can use the `children` prop to display an icon or a custom element.
+
+<Canvas of={stories.Placeholder} />
+
+### Shapes
+
+Use the `design` prop to display a square avatar.
+
+<Canvas of={stories.Shapes} />
+
+### Sizes
+
+The Avatar component comes in 5 different sizes.
+
+<Canvas of={stories.Sizes} />
+
+## API Reference
+
+<ArgTypes
+  of={Avatar}
+  description="Main container for the avatar."
+  subcomponents={{
+    'Avatar.User': {
+      of: Avatar.User,
+      description: 'Preview section of the user (either a profile pic or a placeholder)',
+    },
+    'Avatar.Image': {
+      of: Avatar.Image,
+      description: 'Component to display the avatar image.',
+    },
+    'Avatar.Placeholder': {
+      of: Avatar.Placeholder,
+      description: 'Placeholder to display in case there is no image or the image is not available.',
+    },
+    'Avatar.OnlineBadge': {
+      of: Avatar.OnlineBadge,
+      description: 'Badge to display the online status of the user.',
+    },
+    'Avatar.Action': {
+      of: Avatar.Action,
+      description: 'Edit button positioned on the avatar border.',
+    },
+  }}
+/>
+
+
+## Accessibility
+
+<A11yReport of="avatar" />
+
+The Avatar component follows accessibility best practices:
+
+- The avatar image has an `alt` attribute that uses the provided username
+- The edit button has an accessible label
+- The online status badge uses semantic colors
+- Sizes are sufficient to be clickable on mobile 

--- a/packages/components/src/avatar/avatar.stories.tsx
+++ b/packages/components/src/avatar/avatar.stories.tsx
@@ -1,0 +1,233 @@
+import { StoryLabel } from '@docs/helpers/StoryLabel'
+import { Spinner } from '@spark-ui/components/spinner'
+import { AccountOutline } from '@spark-ui/icons/AccountOutline'
+import { ShareOutline } from '@spark-ui/icons/ShareOutline'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react'
+
+import { Button } from '../button'
+import { Icon } from '../icon'
+import { Avatar } from '.'
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['todo'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Avatar>
+
+export const Default: Story = {
+  args: {
+    size: 'xl',
+    isOnline: true,
+    username: 'John Doe',
+    onlineText: 'Online',
+  },
+  render: args => (
+    <Avatar {...args}>
+      <Avatar.User>
+        <Avatar.Placeholder />
+        <Avatar.Image src="https://github.com/shadcn.png" />
+      </Avatar.User>
+
+      <Avatar.OnlineBadge />
+    </Avatar>
+  ),
+}
+
+export const WithOnlineStatus: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Avatar size="xl" isOnline username="John Doe" onlineText="Online">
+        <Avatar.User>
+          <Avatar.Placeholder />
+          <Avatar.Image src="https://github.com/shadcn.png" />
+        </Avatar.User>
+        <Avatar.OnlineBadge />
+      </Avatar>
+    </div>
+  ),
+}
+
+export const Actions: StoryFn = () => {
+  return (
+    <div>
+      <div className="gap-xl flex flex-wrap items-end">
+        <Avatar size="xl" username="John Doe">
+          <Avatar.User>
+            <Avatar.Placeholder />
+            <Avatar.Image src="https://github.com/shadcn.png" />
+          </Avatar.User>
+          <Avatar.Action ariaLabel="Edit account" />
+        </Avatar>
+
+        <Avatar size="xl" username="John Doe">
+          <Avatar.User>
+            <Avatar.Placeholder />
+            <Avatar.Image src="https://github.com/shadcn.png" />
+          </Avatar.User>
+          <Avatar.Action ariaLabel="Share account">
+            <Icon>
+              <ShareOutline />
+            </Icon>
+          </Avatar.Action>
+        </Avatar>
+
+        <Avatar size="xl" username="John Doe">
+          <Avatar.User>
+            <Avatar.Placeholder />
+            <Avatar.Image src="https://github.com/shadcn.png" />
+          </Avatar.User>
+          <Avatar.Action ariaLabel="Edit account" asChild>
+            <Button size="sm" intent="info" design="outlined" className="bg-surface!">
+              Edit
+            </Button>
+          </Avatar.Action>
+        </Avatar>
+      </div>
+    </div>
+  )
+}
+
+export const AsLink: StoryFn = () => {
+  return (
+    <div className="gap-xl flex">
+      <div className="gap-md flex flex-col">
+        <StoryLabel>Link</StoryLabel>
+        <Avatar size="xl" username="John Doe">
+          <Avatar.User asChild>
+            <a href="#">
+              <Avatar.Placeholder />
+              <Avatar.Image src="https://github.com/shadcn.png" />
+            </a>
+          </Avatar.User>
+        </Avatar>
+      </div>
+
+      <div className="gap-md flex flex-col">
+        <StoryLabel>Button</StoryLabel>
+        <Avatar size="xl" username="John Doe">
+          <Avatar.User asChild>
+            <button type="button" onClick={() => alert('clicked')}>
+              <Avatar.Placeholder />
+              <Avatar.Image src="https://github.com/shadcn.png" />
+            </button>
+          </Avatar.User>
+        </Avatar>
+      </div>
+    </div>
+  )
+}
+
+export const Placeholder: StoryFn = () => {
+  return (
+    <div>
+      <div className="gap-xl flex flex-wrap items-start">
+        <div className="gap-md flex flex-col">
+          <StoryLabel>Default</StoryLabel>
+          <Avatar username="John Doe">
+            <Avatar.User>
+              <Avatar.Placeholder />
+            </Avatar.User>
+          </Avatar>
+        </div>
+        <div className="gap-md flex flex-col">
+          <StoryLabel>Custom - icon</StoryLabel>
+          <Avatar username="John Doe">
+            <Avatar.User>
+              <Avatar.Placeholder className="bg-neutral-container text-on-neutral-container">
+                <Icon>
+                  <AccountOutline />
+                </Icon>
+              </Avatar.Placeholder>
+            </Avatar.User>
+          </Avatar>
+        </div>
+        <div className="gap-md flex flex-col">
+          <StoryLabel>Custom - spinner</StoryLabel>
+          <Avatar username="John Doe">
+            <Avatar.User>
+              <Avatar.Placeholder>
+                <Spinner size="sm" />
+              </Avatar.Placeholder>
+            </Avatar.User>
+          </Avatar>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const Shapes: StoryFn = () => {
+  return (
+    <div>
+      <div className="gap-xl flex flex-wrap items-start">
+        <Avatar design="circle" username="John Doe" isOnline onlineText="Online">
+          <Avatar.User>
+            <Avatar.Placeholder />
+            <Avatar.Image src="https://github.com/shadcn.png" />
+          </Avatar.User>
+          <Avatar.Action ariaLabel="Edit account" />
+          <Avatar.OnlineBadge />
+        </Avatar>
+        <Avatar design="square" username="John Doe" isOnline onlineText="Online">
+          <Avatar.User>
+            <Avatar.Placeholder />
+            <Avatar.Image src="https://github.com/shadcn.png" />
+          </Avatar.User>
+          <Avatar.Action ariaLabel="Edit account" />
+          <Avatar.OnlineBadge />
+        </Avatar>
+      </div>
+    </div>
+  )
+}
+
+export const Sizes: StoryFn = () => {
+  const sizes = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const
+
+  return (
+    <div>
+      <div className="gap-xl flex flex-wrap items-start">
+        {sizes.map(size => (
+          <div key={size} className="gap-lg flex flex-col">
+            <StoryLabel>{size}</StoryLabel>
+            <Avatar size={size} username="John Doe" isOnline onlineText="Online">
+              <Avatar.User>
+                <Avatar.Placeholder />
+                <Avatar.Image src="https://github.com/shadcn.png" />
+              </Avatar.User>
+              <Avatar.OnlineBadge />
+            </Avatar>
+            <Avatar size={size} username="John Doe" isOnline onlineText="Online">
+              <Avatar.User>
+                <Avatar.Placeholder />
+              </Avatar.User>
+              <Avatar.OnlineBadge />
+            </Avatar>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const CustomAction: StoryFn = () => {
+  return (
+    <div className="gap-xl flex flex-wrap items-end">
+      <Avatar size="xl" username="John Doe">
+        <Avatar.User>
+          <Avatar.Placeholder />
+          <Avatar.Image src="https://github.com/shadcn.png" />
+        </Avatar.User>
+        <Avatar.Action ariaLabel="Edit account" asChild>
+          <Button size="sm" intent="info" design="outlined" className="bg-surface!">
+            Edit
+          </Button>
+        </Avatar.Action>
+      </Avatar>
+    </div>
+  )
+}

--- a/packages/components/src/avatar/context.ts
+++ b/packages/components/src/avatar/context.ts
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import type { AvatarContextValue } from './types'
+
+const AvatarContext = React.createContext<AvatarContextValue | undefined>(undefined)
+
+export const useAvatarContext = () => {
+  const context = React.useContext(AvatarContext)
+  if (!context) {
+    throw new Error('useAvatarContext must be used within an Avatar component')
+  }
+  return context
+}
+
+export { AvatarContext }

--- a/packages/components/src/avatar/index.ts
+++ b/packages/components/src/avatar/index.ts
@@ -1,0 +1,25 @@
+import { Avatar } from './Avatar'
+import { AvatarImage } from './AvatarImage'
+import { AvatarAction } from './AvatarAction'
+import { AvatarOnlineBadge } from './AvatarOnlineBadge'
+import { AvatarUser } from './AvatarUser'
+import { AvatarPlaceholder } from './AvatarPlaceholder'
+import type { AvatarProps } from './types'
+
+export interface AvatarComponent
+  extends React.ForwardRefExoticComponent<AvatarProps & React.RefAttributes<HTMLDivElement>> {
+  Image: typeof AvatarImage
+  Action: typeof AvatarAction
+  OnlineBadge: typeof AvatarOnlineBadge
+  User: typeof AvatarUser
+  Placeholder: typeof AvatarPlaceholder
+}
+
+const AvatarComponent = Avatar as AvatarComponent
+
+AvatarComponent.Image = AvatarImage
+AvatarComponent.Action = AvatarAction
+AvatarComponent.OnlineBadge = AvatarOnlineBadge
+AvatarComponent.User = AvatarUser
+AvatarComponent.Placeholder = AvatarPlaceholder
+export { AvatarComponent as Avatar }

--- a/packages/components/src/avatar/types.ts
+++ b/packages/components/src/avatar/types.ts
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { AvatarImage } from './AvatarImage'
+import { AvatarAction } from './AvatarAction'
+
+export interface AvatarContextValue {
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+  isOnline: boolean
+  onlineText?: string
+  username: string
+  src?: string
+  design: 'circle' | 'square'
+  pixelSize: number
+}
+
+export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+  isOnline?: boolean
+  onlineText?: string
+  username: string
+  asChild?: boolean
+  design?: 'circle' | 'square'
+}
+
+export interface AvatarComponent
+  extends React.ForwardRefExoticComponent<AvatarProps & React.RefAttributes<HTMLDivElement>> {
+  Image: typeof AvatarImage
+  Action: typeof AvatarAction
+}

--- a/packages/components/src/badge/Badge.stories.tsx
+++ b/packages/components/src/badge/Badge.stories.tsx
@@ -89,9 +89,9 @@ export const CountThreshold: StoryFn = _args => (
 export const Sizes: StoryFn = _args => (
   <div className="gap-xl flex">
     {sizes.map(size => (
-      <div className="gap-xl flex" key={size}>
+      <div className="gap-xl flex flex-col" key={size}>
         <div className="text-center">
-          <StoryLabel className="mb-xl">{`
+          <StoryLabel className="mb-md">{`
             ${size}
             ${size === 'md' ? ' (default)' : ''}
           `}</StoryLabel>
@@ -102,7 +102,7 @@ export const Sizes: StoryFn = _args => (
         </div>
 
         <div className="text-center">
-          <StoryLabel className="mb-xl">{`
+          <StoryLabel className="mb-md">{`
             ${size}
             ${size === 'md' ? ' (default)' : ''}
             empty
@@ -111,6 +111,30 @@ export const Sizes: StoryFn = _args => (
           <Badge key={size} size={size}>
             {fakeAvatar}
           </Badge>
+        </div>
+
+        <div className="text-center">
+          <StoryLabel className="mb-md">{`
+            ${size}
+            ${size === 'md' ? ' (default)' : ''}
+            standalone with count
+          `}</StoryLabel>
+
+          <div className="bg-overlay/dim-3 p-md flex items-center justify-center">
+            <Badge key={size} size={size} count={25} />
+          </div>
+        </div>
+
+        <div className="text-center">
+          <StoryLabel className="mb-md">{`
+            ${size}
+            ${size === 'md' ? ' (default)' : ''}
+            standalone
+          `}</StoryLabel>
+
+          <div className="bg-overlay/dim-3 p-md flex items-center justify-center">
+            <Badge key={size} size={size} />
+          </div>
         </div>
       </div>
     ))}

--- a/packages/components/src/badge/BadgeItem.styles.tsx
+++ b/packages/components/src/badge/BadgeItem.styles.tsx
@@ -2,7 +2,12 @@ import { makeVariants } from '@spark-ui/internal-utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 export const styles = cva(
-  ['inline-flex h-fit', 'empty:p-0', 'text-center font-bold', 'rounded-full box-content'],
+  [
+    'inline-flex h-fit',
+    'empty:p-0',
+    'text-center font-bold default:border-surface',
+    'rounded-full box-content',
+  ],
   {
     variants: {
       /**
@@ -24,16 +29,16 @@ export const styles = cva(
           'basic',
         ]
       >({
-        main: ['bg-main', 'text-on-main', 'border-surface'],
-        support: ['bg-support', 'text-on-support', 'border-surface'],
-        accent: ['bg-accent', 'text-on-accent', 'border-surface'],
-        success: ['bg-success', 'text-on-success', 'border-surface'],
-        alert: ['bg-alert', 'text-on-alert', 'border-surface'],
-        danger: ['bg-error', 'text-on-error', 'border-surface'],
-        info: ['bg-info', 'text-on-info', 'border-surface'],
-        neutral: ['bg-neutral', 'text-on-neutral', 'border-surface'],
-        surface: ['bg-surface', 'text-on-surface', 'border-surface'],
-        basic: ['bg-basic', 'text-on-basic', 'border-surface'],
+        main: ['bg-main text-on-main'],
+        support: ['bg-support text-on-support'],
+        accent: ['bg-accent text-on-accent'],
+        success: ['bg-success text-on-success'],
+        alert: ['bg-alert text-on-alert'],
+        danger: ['bg-error text-on-error'],
+        info: ['bg-info text-on-info'],
+        neutral: ['bg-neutral text-on-neutral'],
+        surface: ['bg-surface text-on-surface'],
+        basic: ['bg-basic text-on-basic'],
       }),
       /**
        * Size of the component.
@@ -48,10 +53,22 @@ export const styles = cva(
        * @default 'relative'
        */
       type: {
-        relative: ['absolute right-0 border-md', 'translate-x-1/2 -translate-y-1/2'],
-        standalone: [],
+        relative: ['absolute right-0 default:border-md', 'translate-x-1/2 -translate-y-1/2'],
+        standalone: ['border-surface'],
       },
     },
+    compoundVariants: [
+      {
+        size: 'sm',
+        type: 'standalone',
+        className: 'border-md',
+      },
+      {
+        size: 'md',
+        type: 'standalone',
+        className: 'border-lg',
+      },
+    ],
     defaultVariants: {
       intent: 'danger',
       size: 'md',

--- a/packages/utils/theme/src/theme.css
+++ b/packages/utils/theme/src/theme.css
@@ -18,15 +18,17 @@
   --border-width-0: 0px;
   --border-width-sm: 1px;
   --border-width-md: 2px;
+  --border-width-lg: 4px;
 
   --breakpoint-sm: 640px;
   --breakpoint-md: 768px;
   --breakpoint-lg: 1024px;
   --breakpoint-xl: 1280px;
 
-  --font-sans: 'Nunito Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-sans:
+    'Nunito Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   --font-weight-regular: 400;


### PR DESCRIPTION
### Description, Motivation and Context

- new Avatar component.
- new `lg` size (4px) for border-radius tokens.
- `Badge` update: standalone + size="md" now has a 4px border.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

### Screenshots - Animations


![Capture d’écran 2025-03-27 à 16 35 16](https://github.com/user-attachments/assets/246b159f-c125-4e12-a433-84934350778f)
