### PR TITLE
feat(components): progress - screen reader optimization

### DIFF
--- a/packages/components/src/progress/Progress.doc.mdx
+++ b/packages/components/src/progress/Progress.doc.mdx
@@ -1,6 +1,8 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { Callout } from '@docs/helpers/Callout'
+import { TextLink } from '@spark-ui/components/text-link'
 
 import { Progress } from '.'
 
@@ -10,7 +12,15 @@ import * as stories from './Progress.stories'
 
 # Progress
 
-Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
+A progressbar indicates that the user's request has been received and the application is making progress toward completing the requested action.
+
+<Callout kind="warning">
+  <p>
+    Do not use this component as a step indicator. It indicates a timed event with a beginning and an end.
+  </p>
+  <p>This component is also different than the <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/meter/">Meter</TextLink> pattern.</p>
+</Callout>
+
 
 <Canvas of={stories.Default} />
 
@@ -113,8 +123,21 @@ Displaying the progress value as text is possible by composing the different com
 
 <A11yReport of="progress" />
 
-Adheres to the [Meter WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/meter/).
+Adheres to the [progressbar WAI-ARIA role](https://www.w3.org/TR/wai-aria-1.1/#progressbar). There is no pattern for the progressbar.
 
 ### Guidelines
 
 - Usage of `aria-label` or `Progress.Label` is **mandatory**. It serves as the accessible name for the progress.
+
+- The author **SHOULD** supply values for `aria-valuenow`, `aria-valuemin`, and `aria-valuemax`, unless the value is indeterminate, in which case the author **SHOULD** omit the `aria-valuenow` attribute. 
+
+- Authors **SHOULD** update these values when the visual progress indicator is updated. 
+
+- If the progressbar is describing the loading progress of a particular region of a page, the author **SHOULD** use `aria-describedby` to point to the status, and set the `aria-busy` attribute to `true` on the region until it is finished loading. 
+
+- It is not possible for the user to alter the value of a progressbar because it is always readonly.
+
+### Screen reader
+
+ - As your loading start, the focus must be forwarded to the progressbar (use a ref).
+ - When the loading is finished, the focus must be forwarded to loaded region or first focusable element inside the loaded region.

--- a/packages/components/src/progress/Progress.stories.tsx
+++ b/packages/components/src/progress/Progress.stories.tsx
@@ -1,5 +1,6 @@
+import { Button } from '@spark-ui/components/button'
 import { Meta, StoryFn } from '@storybook/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Progress, ProgressProps } from '.'
 
@@ -18,8 +19,60 @@ const meta: Meta<typeof Progress> = {
 
 export default meta
 
-export const Default: StoryFn = _args => {
-  return <Progress value={20} aria-label="Loading" />
+export const Default: StoryFn = () => {
+  const [value, setValue] = useState(0)
+
+  const progressRef = useRef<HTMLDivElement>(null)
+  const loadedSectionRef = useRef<HTMLDivElement>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(null)
+
+  const max = 100
+  const step = 10
+
+  const onLoadStart = () => {
+    intervalRef.current && clearInterval(intervalRef.current)
+    setValue(0)
+    progressRef.current?.focus()
+  }
+
+  const onLoadComplete = () => {
+    intervalRef.current && clearInterval(intervalRef.current)
+    loadedSectionRef.current?.focus()
+  }
+
+  const startLoading = () => {
+    onLoadStart()
+
+    intervalRef.current = setInterval(() => {
+      setValue(v => {
+        const newValue = v + step
+
+        if (newValue === max) onLoadComplete()
+
+        return newValue
+      })
+    }, 500)
+  }
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <Progress max={max} value={value} aria-label="Loading" ref={progressRef} />
+
+      {value !== 0 && (
+        <div
+          ref={loadedSectionRef}
+          tabIndex={-1}
+          className="p-lg bg-surface text-on-surface border-sm border-outline gap-md flex rounded-md"
+        >
+          <span>{value < max ? 'Loading...' : 'Section loaded !'}</span>
+        </div>
+      )}
+
+      <Button onClick={startLoading} className="self-start">
+        {value === 0 ? 'Load section' : 'Reload section'}
+      </Button>
+    </div>
+  )
 }
 
 export const Value: StoryFn = () => {
@@ -30,7 +83,7 @@ export const Value: StoryFn = () => {
       const step = 10
 
       setValue(value => (value + step) % (100 + step))
-    }, 500)
+    }, 2000)
 
     return () => clearInterval(interval)
   }, [])

--- a/packages/components/src/progress/Progress.tsx
+++ b/packages/components/src/progress/Progress.tsx
@@ -35,10 +35,11 @@ export const Progress = ({
     <ProgressContext.Provider data-spark-component="progress" value={value}>
       <RadixProgress.Progress
         ref={ref}
-        className={cx('gap-sm flex flex-col', className)}
+        className={cx('gap-sm focus-visible:u-outline flex flex-col', className)}
         value={valueProp}
         aria-labelledby={labelId}
         max={max}
+        tabIndex={-1}
         {...others}
       >
         {children}


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [SPA-565](https://jira.ets.mpi-internal.com/browse/SPA-565)

### Description, Motivation and Context

- allow `Progress` to be focusable programatically.
- guidance to properly manage focus forwarding when using a progress bar.
- updated references to the wrong W3C pattern (Meter) top `progressbar` role.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 📷 Demo

### Screenshots - Animations

https://github.com/user-attachments/assets/8a49cba0-74c8-45ef-aba6-ec238c60616f


