### PR TITLE
fix(components): combobox - sync async options load  with input

### DIFF
--- a/packages/components/src/combobox/Combobox.doc.mdx
+++ b/packages/components/src/combobox/Combobox.doc.mdx
@@ -160,6 +160,8 @@ Use `readOnly` prop to indicate the combobox is only readable.
 Use the `isLoading` prop to render the combobox in loading state.
 This will prepend a spinner inside the items-list.
 
+In case you passed a `value` or `defaultValue` prop, the combobox input will show the placeholder until the matching option is loaded (unless you use the combobox with `allowCustomValue` prop).
+
 <Canvas of={stories.IsLoading} />
 
 ### Status

--- a/packages/components/src/combobox/Combobox.stories.tsx
+++ b/packages/components/src/combobox/Combobox.stories.tsx
@@ -497,8 +497,8 @@ export const MultipleSelectionControlled: StoryFn = () => {
   const [inputValue, setInputValue] = useState<string>('')
 
   return (
-    <div className="gap-lg flex flex-wrap pb-[300px]">
-      <div className="gap-lg flex flex-col">
+    <div className="gap-lg flex pb-[300px]">
+      <div className="gap-lg flex shrink-0 flex-col">
         <FormField>
           <FormField.Label className="font-bold">Opened state:</FormField.Label>
           <Switch checked={open} onCheckedChange={setOpen}>
@@ -536,6 +536,7 @@ export const MultipleSelectionControlled: StoryFn = () => {
         onValueChange={setValue}
         open={open}
         onOpenChange={setOpen}
+        allowCustomValue
       >
         <Combobox.Trigger>
           <Combobox.SelectedItems />
@@ -831,9 +832,38 @@ export const FormFieldValidation: StoryFn = () => {
 }
 
 export const IsLoading: StoryFn = _args => {
+  const [books, setBooks] = useState<Record<string, string>>({})
+  const [isLoading, setIsLoading] = useState(false)
+
+  const reloadOptions = () => {
+    setIsLoading(true)
+    setBooks({})
+
+    setTimeout(() => {
+      setIsLoading(false)
+
+      setBooks({
+        'book-1': 'To Kill a Mockingbird',
+        'book-2': 'War and Peace',
+        'book-3': 'The Idiot',
+        'book-4': 'A Picture of Dorian Gray',
+        'book-5': '1984',
+        'book-6': 'Pride and Prejudice',
+      })
+    }, 2000)
+  }
+
   return (
-    <div className="pb-[300px]">
-      <Combobox isLoading>
+    <div className="gap-lg flex flex-col pb-[300px]">
+      <Button
+        onClick={reloadOptions}
+        isLoading={isLoading}
+        loadingLabel="Loading"
+        className="self-start"
+      >
+        Load options
+      </Button>
+      <Combobox defaultValue="book-2" isLoading={isLoading}>
         <Combobox.Trigger>
           <Combobox.LeadingIcon>
             <PenOutline />
@@ -846,14 +876,11 @@ export const IsLoading: StoryFn = _args => {
         <Combobox.Popover>
           <Combobox.Items>
             <Combobox.Empty>No results found</Combobox.Empty>
-            <Combobox.Item value="book-1">To Kill a Mockingbird</Combobox.Item>
-            <Combobox.Item value="book-2">War and Peace</Combobox.Item>
-            <Combobox.Item value="book-3">The Idiot</Combobox.Item>
-            <Combobox.Item value="book-4">A Picture of Dorian Gray</Combobox.Item>
-            <Combobox.Item value="book-5">1984</Combobox.Item>
-            <Combobox.Item value="book-6">
-              Pride and Prejudice but it is an extremely long title
-            </Combobox.Item>
+            {Object.entries(books).map(([key, label]) => (
+              <Combobox.Item key={key} value={key}>
+                {label}
+              </Combobox.Item>
+            ))}
           </Combobox.Items>
         </Combobox.Popover>
       </Combobox>

--- a/packages/components/src/combobox/ComboboxContext.tsx
+++ b/packages/components/src/combobox/ComboboxContext.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 /* eslint-disable max-lines-per-function */
 import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/hooks/use-combined-state'
@@ -224,12 +223,11 @@ export const ComboboxProvider = ({
         },
         []
       )
-
       setSelectedItems(comboboxValue ? newSelectedItems : [])
     } else {
       setSelectedItem(itemsMap.get(comboboxValue as string) || null)
     }
-  }, [multiple ? JSON.stringify(comboboxValue) : comboboxValue])
+  }, [multiple ? JSON.stringify(comboboxValue) : comboboxValue, itemsMap])
 
   // Form field state
   const field = useFormFieldControl()


### PR DESCRIPTION
<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [SPA-626](https://jira.ets.mpi-internal.com/browse/SPA-626)

### Description, Motivation and Context
Realistically, combobox items are often loaded asynchronously after a call to a service.

- It means The input of the combobox has no access to the items values and labels.
- It means the input CAN'T display the selected item label until the data is loaded, it will just display the placeholder until it is.

The bug is:

once the items are loaded/rendered, the input does not sync with it and remains empty instead of showing the selected item label, giving the user the impression that no value is selected.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧾 Documentation
