### PR TITLE
docs(components): aria role cards in mdx

### DIFF
--- a/documentation/helpers/AriaRole/index.tsx
+++ b/documentation/helpers/AriaRole/index.tsx
@@ -1,0 +1,175 @@
+import { Breadcrumb } from '@spark-ui/components/breadcrumb'
+import { Icon } from '@spark-ui/components/icon'
+import { Tag } from '@spark-ui/components/tag'
+import { TextLink } from '@spark-ui/components/text-link'
+import { WarningFill } from '@spark-ui/icons/WarningFill'
+import {
+  aria,
+  ARIAProperty,
+  ARIARoleDefinition,
+  ARIARoleDefinitionKey,
+  roleElements,
+  roles,
+} from 'aria-query'
+
+import { rolesDescriptions } from './rolesDescriptions'
+
+const AriaPath = ({ name, roleData }: { name: string; roleData: ARIARoleDefinition }) => {
+  const superClasses = roleData?.superClass[0]
+
+  if (!roleData) return null
+
+  return (
+    superClasses && (
+      <Breadcrumb aria-label="Breadcrumb">
+        {superClasses.map((superClass, index) => {
+          return (
+            <>
+              <Breadcrumb.Item key={index}>
+                <Breadcrumb.Link
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`https://www.w3.org/TR/wai-aria-1.2/#${superClass}`}
+                >
+                  {superClass}
+                </Breadcrumb.Link>
+              </Breadcrumb.Item>
+              <Breadcrumb.Separator />
+            </>
+          )
+        })}
+        <Breadcrumb.Item>
+          <Breadcrumb.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`https://www.w3.org/TR/wai-aria-1.2/#${name}`}
+          >
+            {name}
+          </Breadcrumb.Link>
+        </Breadcrumb.Item>
+      </Breadcrumb>
+    )
+  )
+}
+
+const AriaAttribute = ({
+  prop,
+  type,
+}: {
+  prop: ARIAProperty
+  type: 'required' | 'authorized' | 'forbidden'
+}) => {
+  const intentsMap = {
+    required: 'success',
+    authorized: 'info',
+    forbidden: 'danger',
+  } as const
+
+  return (
+    <Tag key={prop} intent={intentsMap[type]} design="tinted" asChild>
+      <TextLink
+        target="_blank"
+        rel="noopener noreferrer"
+        href={`https://www.w3.org/TR/wai-aria-1.2/#${prop}`}
+        underline={false}
+      >
+        {prop} ({aria.get(prop as ARIAProperty)?.type})
+        {type !== 'authorized' && (
+          <Icon>
+            <WarningFill />
+          </Icon>
+        )}
+      </TextLink>
+    </Tag>
+  )
+}
+
+export const AriaRole = ({ role }: { role: ARIARoleDefinitionKey }) => {
+  const roleData = roles.get(role)
+  const htmlTags = roleElements.get(role)
+
+  const ariaProps = Object.keys(roleData?.props || {})
+  const ariaRequiredProps = Object.keys(roleData?.requiredProps || {})
+  const ariaProhibitedProps = roleData?.prohibitedProps || []
+
+  if (!roleData) return null
+
+  return (
+    <div className="sb-unstyled bg-surface text-on-surface gap-md relative flex flex-col">
+      <div>
+        <AriaPath name={role} roleData={roleData} />
+        <p className="text-display-2">{role}</p>
+        <Tag className="top-md right-md absolute" design="outlined" intent="info">
+          WAI-ARIA 2.1
+        </Tag>
+      </div>
+
+      <p>{rolesDescriptions[role as keyof typeof rolesDescriptions]}</p>
+
+      {htmlTags && (
+        <div className="gap-md flex flex-col">
+          <p className="text-headline-2">HTML Elements:</p>
+
+          <div className="gap-sm flex flex-wrap">
+            {Array.from(htmlTags).map(({ name, attributes }, index) => {
+              return (
+                <div
+                  key={index}
+                  className="bg-neutral-container text-on-neutral-container px-md rounded-sm font-bold"
+                >
+                  {'<'}
+                  {name}{' '}
+                  {attributes &&
+                    attributes.map(({ name, value }) => {
+                      return (
+                        <>
+                          <span key={name}>
+                            {name}="{value}"
+                          </span>
+                          <span> </span>
+                        </>
+                      )
+                    })}
+                  {' />'}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {ariaRequiredProps.length > 0 && (
+        <div className="gap-md flex flex-col">
+          <p className="text-headline-2">Required attributes:</p>
+          <div className="gap-sm flex flex-wrap">
+            {ariaRequiredProps.map(prop => (
+              <AriaAttribute key={prop} prop={prop as ARIAProperty} type="required" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {ariaProps.length > 0 && (
+        <div className="gap-md flex flex-col">
+          <p className="text-headline-2">Authorized attributes:</p>
+          <div className="gap-sm flex flex-wrap">
+            {ariaProps.map(prop => (
+              <AriaAttribute key={prop} prop={prop as ARIAProperty} type="authorized" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(ariaProhibitedProps as unknown as any[]).length > 0 && (
+        <div className="gap-md flex flex-col">
+          <p className="text-headline-2">Prohibited attributes:</p>
+          <div className="gap-sm flex flex-wrap">
+            {(ariaProhibitedProps as unknown as any[]).map(prop => (
+              <AriaAttribute key={prop} prop={prop as ARIAProperty} type="forbidden" />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/documentation/helpers/AriaRole/rolesDescriptions.ts
+++ b/documentation/helpers/AriaRole/rolesDescriptions.ts
@@ -1,0 +1,115 @@
+export const rolesDescriptions = {
+  alert: 'A message with important, and usually time-sensitive, information.',
+  alertdialog:
+    'A type of dialog that contains an alert message, where initial focus goes to an element within the dialog.',
+  application: 'A region declared as a web application, as opposed to a web document.',
+  article:
+    'A section of a page that consists of a composition that forms an independent part of a document, page, or site.',
+  banner: 'A region that contains mostly site-oriented content, rather than page-specific content.',
+  blockquote: 'A section of content that is quoted from another source.',
+  button: 'An input that allows for user-triggered actions when clicked or pressed.',
+  caption: 'Visible content that names, and may also describe, a figure, table, grid, or treegrid.',
+  cell: 'A cell in a tabular container.',
+  checkbox: 'A checkable input that has three possible values: true, false, or mixed.',
+  code: 'A section whose content represents a fragment of computer code.',
+  columnheader: 'A cell containing header information for a column.',
+  combobox:
+    'A presentation of a select; usually similar to a textbox where users can type ahead to select an option, or type to enter arbitrary text as a new item in the list.',
+  command: 'A form of widget that performs an action but does not receive input data.',
+  complementary:
+    'A supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.',
+  composite: 'A widget that may contain navigable descendants or owned children.',
+  contentinfo: 'A large perceivable region that contains information about the parent document.',
+  definition: 'A definition of a term or concept.',
+  deletion:
+    'A deletion contains content that is marked as removed or content that is being suggested for removal.',
+  dialog:
+    'An application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.',
+  directory: 'A list of references to members of a group, such as a static table of contents.',
+  document:
+    'A region containing related information that is declared as document content, as opposed to a web application.',
+  emphasis: 'One or more emphasized characters.',
+  feed: 'A scrollable list of articles where scrolling may cause articles to be added to or removed from either end of the list.',
+  figure:
+    'A perceivable section of content that typically contains a graphical document, images, code snippets, or example text. The parts of a figure MAY be user-navigable.',
+  form: 'A landmark region that contains a collection of items and objects that, as a whole, combine to create a form.',
+  generic: ' A nameless container element that has no semantic meaning on its own.',
+  grid: 'An interactive control which contains cells of tabular data arranged in rows and columns, like a table.',
+  gridcell: 'A cell in a grid or treegrid.',
+  group:
+    'A set of user interface objects which are not intended to be included in a page summary or table of contents by assistive technologies.',
+  heading: 'A heading for a section of the page.',
+  img: 'A container for a collection of elements that form an image.',
+  input: 'A generic type of widget that allows user input.',
+  insertion:
+    'An insertion contains content that is marked as added or content that is being suggested for addition.',
+  landmark: 'A region of the page intended as a navigational landmark.',
+  link: 'An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource.',
+  list: 'A group of non-interactive list items.',
+  listbox: 'Allows the user to select one or more items from a list of choices',
+  listitem: 'A single item in a list or directory.',
+  log: 'A type of live region where new information is added in meaningful order and old information may disappear.',
+  main: 'The main content of a document.',
+  marquee: 'A type of live region where non-essential information changes frequently',
+  math: 'Content that represents a mathematical expression.',
+  menu: 'A type of widget that offers a list of choices to the user.',
+  menubar:
+    'A presentation of menu that usually remains visible and is usually presented horizontally.',
+  menuitem: '',
+  menuitemcheckbox:
+    'A menuitem with a checkable state whose possible values are true, false, or mixed.',
+  menuitemradio:
+    'A checkable menuitem in a set of elements with role menuitemradio, only one of which can be checked at a time.',
+  meter:
+    'An element that represents a scalar measurement within a known range, or a fractional value.',
+  navigation:
+    'A collection of navigational elements (usually links) for navigating the document or related documents.',
+  note: 'A section whose content is parenthetic or ancillary to the main content of the resource.',
+  option: 'A selectable item in a select list.',
+  paragraph: 'A paragraph of content.',
+  presentation: '',
+  progressbar: 'An element that displays the progress status for tasks that take a long time.',
+  radio: 'A checkable input in a group of radio roles, only one of which can be checked at a time.',
+  radiogroup: 'A group of radio buttons.',
+  range: 'An input representing a range of values that can be set by the user.',
+  region:
+    'A large perceivable section of a web page or document, that is important enough to be included in a page summary or table of contents.',
+  roletype: 'The base role from which all other roles in this taxonomy inherit.',
+  row: 'A row of cells in a grid.',
+  rowgroup: 'A group containing one or more row elements in a grid.',
+  rowheader: 'A cell containing header information for a row in a grid.',
+  scrollbar: 'A graphical object that controls the scrolling of content within a viewing area.',
+  search:
+    'A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility.',
+  searchbox: 'A type of textbox intended for specifying search criteria.',
+  section: 'A renderable structural containment unit in a document or application',
+  sectionhead: 'A structure that labels or summarizes the topic of its related section.',
+  select: 'A structure that labels or summarizes the topic of its related section.',
+  separator:
+    'A divider that separates and distinguishes sections of content or groups of menu items',
+  slider: 'A user input where the user selects a value from within a given range.',
+  spinbutton: 'A form of range that expects the user to select from among discrete choices.',
+  status:
+    'A container whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.',
+  strong: 'Content that is important, serious, or urgent.',
+  structure: 'A document structural element.',
+  tab: 'A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.',
+  Table: 'A section containing data arranged in rows and columns',
+  tablist: 'A list of tab elements, which are references to tabpanel elements.',
+  tabpanel:
+    'A container for the resources associated with a tab, where each tab is contained in a tablist.',
+  term: 'The term role is used to explicitly identify a word or phrase for which a definition has been provided by the author or is expected to be provided by the user.: ',
+  textbox: 'Input that allows free-form text as its value.',
+  time: 'An element that represents a specific point in time.',
+  timer:
+    'A type of live region containing a numerical counter which indicates an amount of elapsed time from a start point, or the time remaining until an end point.',
+  toolbar:
+    'A collection of commonly used function buttons or controls represented in compact visual form.',
+  tooltip: 'A contextual popup that displays a description for an element.',
+  tree: 'A type of list that may contain sub-level nested groups that can be collapsed and expanded.',
+  treegrid: 'A grid whose rows can be expanded and collapsed in the same manner as for a tree.',
+  treeitem: 'An option item of a tree',
+  widget: 'An interactive component of a graphical user interface (GUI).',
+  window: 'A browser or application window.',
+  none: 'An element whose implicit native role semantics will not be mapped to the accessibility API.',
+}

--- a/documentation/helpers/AriaRoles/index.tsx
+++ b/documentation/helpers/AriaRoles/index.tsx
@@ -1,0 +1,78 @@
+import { Tabs, type TabsProps } from '@spark-ui/components/tabs'
+import { ARIARoleDefinitionKey } from 'aria-query'
+import { type FC, useEffect, useState } from 'react'
+
+import { AriaRole } from '../AriaRole'
+
+interface Props<T> {
+  of: T
+  role: ARIARoleDefinitionKey
+  subcomponents?: Record<string, any> | null
+}
+
+function useTabsOrientation() {
+  const [tabsOrientation, setTabsOrientation] = useState<TabsProps['orientation']>(
+    window.innerWidth < 640 ? 'horizontal' : 'vertical'
+  )
+
+  useEffect(() => {
+    const handleResize = () => {
+      setTabsOrientation(window.innerWidth < 640 ? 'horizontal' : 'vertical')
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  return tabsOrientation
+}
+
+export const AriaRoles = <T extends FC>({ of, role, subcomponents = null }: Props<T>) => {
+  const tabsOrientation = useTabsOrientation()
+
+  const { displayName: name = 'Root' } = of // "Root" in case the root component is missing a displayName
+
+  if (!subcomponents) {
+    return <AriaRole role={role} />
+  }
+
+  const subComponentsList = Object.entries(subcomponents)
+
+  return (
+    <div>
+      <Tabs
+        defaultValue={name}
+        orientation={tabsOrientation}
+        className="sb-unstyled mt-xl overflow-hidden rounded-md"
+      >
+        <Tabs.List className={tabsOrientation === 'horizontal' ? 'mb-md' : ''}>
+          <Tabs.Trigger key={name} value={name} className="text-support bg-transparent">
+            {name}
+          </Tabs.Trigger>
+          <>
+            {subComponentsList.map(([name]) => (
+              <Tabs.Trigger key={name} value={name} className="text-on-surface bg-transparent">
+                {name}
+              </Tabs.Trigger>
+            ))}
+          </>
+        </Tabs.List>
+
+        <Tabs.Content key={name} value={name} className="py-lg">
+          <AriaRole role={role} />
+        </Tabs.Content>
+
+        {subComponentsList.map(([name, { role }]) => {
+          return (
+            <Tabs.Content key={name} value={name} className="py-lg">
+              <AriaRole role={role} />
+            </Tabs.Content>
+          )
+        })}
+      </Tabs>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.1.1",
         "@vitest/ui": "3.1.1",
+        "aria-query": "^5.3.2",
         "babel-loader": "10.0.0",
         "browserslist-to-esbuild": "2.1.1",
         "chalk": "^5.4.1",
@@ -8786,6 +8787,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/@testing-library/dom/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10400,12 +10410,12 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/array-buffer-byte-length": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.1.1",
     "@vitest/ui": "3.1.1",
+    "aria-query": "^5.3.2",
     "babel-loader": "10.0.0",
     "browserslist-to-esbuild": "2.1.1",
     "chalk": "^5.4.1",

--- a/packages/components/src/accordion/Accordion.doc.mdx
+++ b/packages/components/src/accordion/Accordion.doc.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { A11yReport } from '@docs/helpers/A11yReport'
+import { AriaRoles } from '@docs/helpers/AriaRoles'
 import { Kbd } from '../kbd'
 import { Accordion } from '.'
 
@@ -143,7 +144,7 @@ Adheres to the [Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/acco
 - <Kbd>End</Kbd> (Optional): When focus is on an accordion header, moves focus to the last accordion
   header.
 
-### WAI-ARIA Roles, States, and Properties
+### Pattern
 
 - The element that shows and hides the content has role [button](https://w3c.github.io/aria/#button).
 - When the content is visible, the element with role button has [aria-expanded](https://w3c.github.io/aria/#aria-expanded) set to `true`. When the content area is hidden, it is set to `false`.
@@ -159,3 +160,24 @@ Adheres to the [Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/acco
 - Optionally, each element that serves as a container for panel content has role [region](https://w3c.github.io/aria/#region) and [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) with a value that refers to the button that controls display of the panel.
   - Avoid using the `region` role in circumstances that create landmark region proliferation, e.g., in an accordion that contains more than approximately 6 panels that can be expanded at the same time.
   - Role `region` is especially helpful to the perception of structure by screen reader users when panels contain heading elements or a nested accordion.
+
+### Roles
+
+<AriaRoles of={Accordion} role="none" subcomponents={{
+  'Accordion.Item': {
+    of: Accordion.Item,
+    role: 'none',
+  },
+    'Accordion.ItemHeader': {
+      of: Accordion.ItemHeader,
+      role: 'heading',
+    },
+    'Accordion.ItemTrigger': {
+      of: Accordion.ItemTrigger,
+      role: 'button',
+    },
+    'Accordion.ItemContent': {
+      of: Accordion.ItemContent,
+      role: 'region',
+    },
+}} />

--- a/packages/components/src/button/Button.doc.mdx
+++ b/packages/components/src/button/Button.doc.mdx
@@ -4,10 +4,12 @@ import { Source } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
 import { Callout } from '@docs/helpers/Callout'
+import { AriaRoles } from '@docs/helpers/AriaRoles'
 import { Button } from '.'
 import * as ButtonStories from './Button.stories'
 
 <Meta of={ButtonStories} />
+
 
 # Button
 
@@ -124,3 +126,7 @@ This component adheres to the [`button` role requirements](https://www.w3.org/WA
 
 - <Kbd>Space</Kbd>: Activates the button
 - <Kbd>Enter</Kbd>: Activates the button
+
+### Roles
+
+<AriaRoles of={Button} role="button" />


### PR DESCRIPTION
### Description, Motivation and Context

New helper components for MDX documentation: `AriaRole` and `AriaRoles`.

Used to display details about aria roles used by each part of a Spark's compound component.

### Types of changes
- [x] 🧾 Documentation

### Screenshots - Animations
![Capture d’écran 2025-04-11 à 11 49 47](https://github.com/user-attachments/assets/6939e56f-6f47-4dbb-9108-17b9975ce089)

