### PR TITLE
fix(components): fixed text color of input native autocomplete text

### DIFF
--- a/packages/components/src/input/Input.styles.ts
+++ b/packages/components/src/input/Input.styles.ts
@@ -10,6 +10,7 @@ export const inputStyles = cva(
     'bg-surface',
     'text-ellipsis text-body-1 text-on-surface',
     'caret-neutral',
+    '[&:-webkit-autofill]:[-webkit-text-fill-color:var(--color-on-surface)]',
     'autofill:shadow-surface autofill:shadow-[inset_0_0_0px_1000px]',
     'disabled:cursor-not-allowed disabled:border-outline disabled:bg-on-surface/dim-5 disabled:text-on-surface/dim-3',
     'read-only:cursor-default read-only:pointer-events-none read-only:bg-on-surface/dim-5',


### PR DESCRIPTION
### Description, Motivation and Context

Bugfix: the native autocomplete feature of webkit browsers is using its own text node which did not inherit from the font color that we set. A custom selector must be used instead.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
- [ ] 
### Screenshots - Animations

https://github.com/user-attachments/assets/08fadb3c-3926-4320-8f60-1f2d514aa7a9



