### PR TITLE
Combobox a11y updates

### DIFF
--- a/e2e/a11y/pages/Tabs.tsx
+++ b/e2e/a11y/pages/Tabs.tsx
@@ -1,8 +1,8 @@
+import { Icon } from '@spark-ui/components/icon'
+import { Tabs } from '@spark-ui/components/tabs'
 import { ConversationFill } from '@spark-ui/icons/ConversationFill'
 import { FireFill } from '@spark-ui/icons/FireFill'
 import { MailFill } from '@spark-ui/icons/MailFill'
-import { Icon } from '@spark-ui/components/icon'
-import { Tabs } from '@spark-ui/components/tabs'
 import React from 'react'
 
 export const A11yTabs = () => (

--- a/packages/components/src/carousel/useCarousel.ts
+++ b/packages/components/src/carousel/useCarousel.ts
@@ -1,12 +1,12 @@
 /* eslint-disable max-lines-per-function */
 import {
+  KeyboardEvent,
   useCallback,
   useEffect,
   useId,
   useLayoutEffect,
   useRef,
   useState,
-  KeyboardEvent,
 } from 'react'
 
 import {
@@ -227,6 +227,13 @@ export const useCarousel = ({
 
     getSlidesContainerProps: (): ComputedSlideGroupProps => ({
       id: `carousel::${carouselId}::item-group`,
+      /**
+       * The carousel pattern was originally designed for a single slide.
+       * When there is more than one slide, the aria-live region is set to off to avoid announcing the whole list of slides.
+       * This is not ideal but we keep it for backwards compatibility.
+       *
+       * @see https://www.w3.org/WAI/ARIA/apg/patterns/carousel/#wai-aria-attributes
+       */
       'aria-live': slidesPerPage > 1 ? 'off' : 'polite',
       'data-scope': DATA_SCOPE,
       'data-part': 'item-group',

--- a/packages/components/src/combobox/ComboboxEmpty.tsx
+++ b/packages/components/src/combobox/ComboboxEmpty.tsx
@@ -6,7 +6,7 @@ import { useComboboxContext } from './ComboboxContext'
 interface EmptyProps {
   className?: string
   children: ReactNode
-  ref?: Ref<HTMLDivElement>
+  ref?: Ref<HTMLLIElement>
 }
 
 export const Empty = ({ className, children, ref: forwardedRef }: EmptyProps) => {
@@ -14,12 +14,14 @@ export const Empty = ({ className, children, ref: forwardedRef }: EmptyProps) =>
   const hasNoItemVisible = ctx.filteredItemsMap.size === 0
 
   return hasNoItemVisible ? (
-    <div
+    <li
       ref={forwardedRef}
+      role="option"
+      aria-selected={false}
       className={cx('px-lg py-md text-body-1 text-on-surface/dim-1', className)}
     >
       {children}
-    </div>
+    </li>
   ) : null
 }
 

--- a/packages/components/src/combobox/ComboboxInput.tsx
+++ b/packages/components/src/combobox/ComboboxInput.tsx
@@ -59,9 +59,14 @@ export const Input = ({
     }
   }, [])
 
-  const [PopoverTrigger, popoverTriggerProps] = ctx.hasPopover
-    ? [Popover.Trigger, { asChild: true, type: undefined }]
-    : [Fragment, {}]
+  const PopoverTrigger = ctx.hasPopover ? Popover.Trigger : Fragment
+  const popoverTriggerProps = ctx.hasPopover
+    ? {
+        asChild: true,
+        type: undefined,
+        'aria-haspopup': undefined,
+      }
+    : {}
 
   const multiselectInputProps = ctx.getDropdownProps()
   const inputRef = useMergeRefs(forwardedRef, ctx.innerInputRef, multiselectInputProps.ref)

--- a/packages/components/src/tabs/Tabs.doc.mdx
+++ b/packages/components/src/tabs/Tabs.doc.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas } from '@storybook/blocks'
 import { A11yReport } from '@docs/helpers/A11yReport'
 import { ArgTypes } from '@docs/helpers/ArgTypes'
+import { AriaRoles } from '@docs/helpers/AriaRoles'
 import { Tabs } from '.'
 import { Kbd } from '@spark-ui/components/kbd'
 
@@ -41,7 +42,7 @@ export default () => (
 
 Use `disabled` prop on item to set related state to it. Other states (`:hover|:focus|...`) are automatically managed.
 
-<Canvas of={stories.State} />
+<Canvas of={stories.Disabled} />
 
 ### Icons
 
@@ -112,6 +113,9 @@ Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/pa
 
 ### Tips
 
+- If the whole tabs area has a title, link it to the `Tabs.List` element using `aria-labelledby` prop.
+- It is advised to use `asChild` on each `Tabs.Trigger` and use the appropriate heading tag according to your page structure.
+
 ### Keyboard Interactions
 
 - <Kbd>Tab</Kbd>: When focus moves onto the tabs, focuses the active trigger. When a trigger is
@@ -126,3 +130,24 @@ Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/pa
   its associated content.
 - <Kbd>Home</Kbd>: Moves focus to the first trigger and activates its associated content.
 - <Kbd>End</Kbd>: Moves focus to the last trigger and activates its associated content.
+
+### Roles
+
+<AriaRoles
+  of={Tabs}
+  role="none"
+  subcomponents={{
+    'Tabs.List': {
+      of: Tabs.List,
+      role: 'tablist',
+    },
+    'Tabs.Trigger': {
+      of: Tabs.Trigger,
+      role: 'tab',
+    },
+    'Tabs.Content': {
+      of: Tabs.Content,
+      role: 'tabpanel',
+    },
+  }}
+/>

--- a/packages/components/src/tabs/Tabs.stories.tsx
+++ b/packages/components/src/tabs/Tabs.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { ConversationFill } from '@spark-ui/icons/ConversationFill'
 import { FireFill } from '@spark-ui/icons/FireFill'
@@ -6,8 +7,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import type { ReactNode } from 'react'
 
 import { Icon } from '../icon'
-import { Tabs, type TabsProps } from '.'
-import type { TabsListProps } from './TabsList'
+import { Tabs } from '.'
 
 const meta: Meta<typeof Tabs> = {
   title: 'Components/Tabs',
@@ -32,183 +32,282 @@ export interface TabItem {
   content: string
 }
 
-const defaultTabs = [
-  {
-    children: <span>Inbox</span>,
-    value: 'tab1',
-    disabled: false,
-    content: 'Your inbox is empty',
-  },
-  {
-    children: <span>Today</span>,
-    value: 'tab2',
-    disabled: false,
-    content: 'Make some coffee',
-  },
-  {
-    children: <span>Upcoming</span>,
-    value: 'tab3',
-    disabled: false,
-    content: 'Order more coffee',
-  },
-]
+export const Default: StoryFn = _args => {
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      content: 'Order more coffee',
+    },
+  ]
 
-const withIconTabs = [
-  {
-    value: 'tab1',
-    children: (
-      <>
-        <Icon size="sm">
-          <MailFill />
-        </Icon>
-        <span>Inbox</span>
-      </>
-    ),
-    content: 'Your inbox is empty',
-    disabled: false,
-  },
-  {
-    children: (
-      <>
-        <Icon size="sm">
-          <ConversationFill />
-        </Icon>
-        <span>Today</span>
-      </>
-    ),
-    value: 'tab2',
-    content: 'Make some coffee',
-    disabled: false,
-  },
-  {
-    children: (
-      <>
-        <Icon size="sm">
-          <FireFill />
-        </Icon>
-        <span>Upcoming</span>
-      </>
-    ),
-    value: 'tab3',
-    content: 'Order more coffee',
-    disabled: false,
-  },
-]
-
-const withIconOnlyTabs = [
-  {
-    value: 'tab1',
-    children: (
-      <Icon size="sm">
-        <MailFill />
-      </Icon>
-    ),
-    a11yLabel: 'Inbox',
-    content: 'Your inbox is empty',
-    disabled: false,
-  },
-  {
-    children: (
-      <Icon size="sm">
-        <ConversationFill />
-      </Icon>
-    ),
-    a11yLabel: 'Today',
-    value: 'tab2',
-    content: 'Make some coffee',
-    disabled: false,
-  },
-  {
-    children: (
-      <Icon size="sm">
-        <FireFill />
-      </Icon>
-    ),
-    a11yLabel: 'Upcoming',
-    value: 'tab3',
-    content: 'Order more coffee',
-    disabled: false,
-  },
-]
-
-export const createTabs = ({
-  rootProps = {},
-  listProps = {},
-  tabs = defaultTabs,
-}: {
-  rootProps?: TabsProps
-  listProps?: Omit<TabsListProps, 'children'>
-  tabs?: TabItem[]
-} = {}) => {
   return (
-    <Tabs defaultValue="tab1" {...rootProps}>
-      <Tabs.List {...listProps}>
-        {tabs.map(({ value, children, disabled, a11yLabel }) => (
-          <Tabs.Trigger key={value} value={value} disabled={disabled} aria-label={a11yLabel}>
-            {children}
-          </Tabs.Trigger>
-        ))}
-      </Tabs.List>
+    <div>
+      <h4 id="tasks-label" className="text-display-2">
+        Tasks
+      </h4>
+      <Tabs defaultValue="tab1">
+        <Tabs.List aria-labelledby="tasks-label">
+          {tabs.map(({ value, children }) => (
+            <Tabs.Trigger key={value} value={value}>
+              {children}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
 
-      {tabs.map(({ content, value }) => (
-        <Tabs.Content key={value} value={value}>
-          <p>{content}</p>
-        </Tabs.Content>
-      ))}
-    </Tabs>
+        {tabs.map(({ content, value }) => (
+          <Tabs.Content key={value} value={value}>
+            <p>{content}</p>
+          </Tabs.Content>
+        ))}
+      </Tabs>
+    </div>
   )
 }
 
-export const Default: StoryFn = _args => <div>{createTabs()}</div>
+export const Icons: StoryFn = _args => {
+  const tabs = [
+    {
+      value: 'tab1',
+      children: (
+        <>
+          <Icon size="sm">
+            <MailFill />
+          </Icon>
+          <span>Inbox</span>
+        </>
+      ),
+      content: 'Your inbox is empty',
+      disabled: false,
+    },
+    {
+      children: (
+        <>
+          <Icon size="sm">
+            <ConversationFill />
+          </Icon>
+          <span>Today</span>
+        </>
+      ),
+      value: 'tab2',
+      content: 'Make some coffee',
+      disabled: false,
+    },
+    {
+      children: (
+        <>
+          <Icon size="sm">
+            <FireFill />
+          </Icon>
+          <span>Upcoming</span>
+        </>
+      ),
+      value: 'tab3',
+      content: 'Order more coffee',
+      disabled: false,
+    },
+  ]
 
-export const Icons: StoryFn = _args => (
-  <div className="gap-lg flex flex-col">
-    <div>
-      <StoryLabel>with icons</StoryLabel>
-      {createTabs({ tabs: withIconTabs, rootProps: { defaultValue: 'tab2' } })}
-    </div>
+  return (
+    <div className="gap-lg flex flex-col">
+      <div>
+        <Tabs defaultValue="tab2">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
 
-    <div>
-      <StoryLabel>with icons only</StoryLabel>
-      {createTabs({ tabs: withIconOnlyTabs, rootProps: { defaultValue: 'tab3' } })}
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
-export const Intent: StoryFn = _args => (
-  <div className="gap-lg flex flex-col">
-    <div>
-      <StoryLabel>basic (default)</StoryLabel>
-      {createTabs()}
-    </div>
-    <div>
-      <StoryLabel>main</StoryLabel>
-      {createTabs({ rootProps: { intent: 'main' } })}
-    </div>
-    <div>
-      <StoryLabel>support</StoryLabel>
-      {createTabs({ rootProps: { intent: 'support' } })}
-    </div>
-  </div>
-)
+export const Intent: StoryFn = _args => {
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      disabled: false,
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      disabled: false,
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      disabled: false,
+      content: 'Order more coffee',
+    },
+  ]
 
-export const Orientation: StoryFn = _args => (
-  <div className="gap-lg flex flex-col">
-    <div>
-      <StoryLabel>horizontal (default)</StoryLabel>
-      {createTabs({ rootProps: { orientation: 'horizontal' } })}
-    </div>
+  return (
+    <div className="gap-lg flex flex-col">
+      <div>
+        <StoryLabel>basic (default)</StoryLabel>
+        <Tabs defaultValue="tab1">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
 
-    <div>
-      <StoryLabel>vertical</StoryLabel>
-      {createTabs({ rootProps: { orientation: 'vertical' } })}
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
+      <div>
+        <StoryLabel>main</StoryLabel>
+        <Tabs defaultValue="tab1" intent="main">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
+      <div>
+        <StoryLabel>support</StoryLabel>
+        <Tabs defaultValue="tab1" intent="support">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
     </div>
-  </div>
-)
+  )
+}
+
+export const Orientation: StoryFn = _args => {
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      disabled: false,
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      disabled: false,
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      disabled: false,
+      content: 'Order more coffee',
+    },
+  ]
+
+  return (
+    <div className="gap-lg flex flex-col">
+      <div>
+        <StoryLabel>horizontal (default)</StoryLabel>
+        <Tabs defaultValue="tab1" orientation="horizontal">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
+
+      <div>
+        <StoryLabel>vertical</StoryLabel>
+        <Tabs defaultValue="tab1" orientation="vertical">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
+    </div>
+  )
+}
 
 export const Overflow: StoryFn = _args => {
   const overflowTabs = [
-    ...defaultTabs,
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      disabled: false,
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      disabled: false,
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      disabled: false,
+      content: 'Order more coffee',
+    },
     {
       children: <span>Pending</span>,
       value: 'tab4',
@@ -233,75 +332,184 @@ export const Overflow: StoryFn = _args => {
     <div className="gap-lg flex flex-col">
       <div className="max-w-sz-464 shrink basis-auto overflow-auto">
         <StoryLabel>with loop</StoryLabel>
-        {createTabs({
-          listProps: { loop: true },
-          tabs: overflowTabs,
-        })}
+        <Tabs defaultValue="tab1">
+          <Tabs.List loop>
+            {overflowTabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {overflowTabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
       </div>
 
       <div className="max-w-sz-464 shrink basis-auto overflow-auto">
         <StoryLabel>without loop (default)</StoryLabel>
-        {createTabs({ tabs: overflowTabs })}
+
+        <Tabs defaultValue="tab1">
+          <Tabs.List>
+            {overflowTabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {overflowTabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
       </div>
     </div>
   )
 }
 
-export const Size: StoryFn = _args => (
-  <div className="gap-lg flex flex-col">
+export const Size: StoryFn = _args => {
+  const sizes = ['xs', 'sm', 'md'] as const
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      disabled: false,
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      disabled: false,
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      disabled: false,
+      content: 'Order more coffee',
+    },
+  ]
+
+  return (
+    <div className="gap-lg flex flex-col">
+      {sizes.map(size => (
+        <div key={size}>
+          <StoryLabel>
+            {size}
+            {size === 'md' && ' (default)'}
+          </StoryLabel>
+          <Tabs defaultValue="tab1" size={size}>
+            <Tabs.List>
+              {tabs.map(({ value, children, disabled }) => (
+                <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                  {children}
+                </Tabs.Trigger>
+              ))}
+            </Tabs.List>
+
+            {tabs.map(({ content, value }) => (
+              <Tabs.Content key={value} value={value}>
+                <p>{content}</p>
+              </Tabs.Content>
+            ))}
+          </Tabs>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export const ForceMount: StoryFn = _args => {
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      disabled: false,
+      content: 'Your inbox is empty',
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      disabled: false,
+      content: 'Make some coffee',
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      disabled: false,
+      content: 'Order more coffee',
+    },
+  ]
+
+  return (
     <div>
-      <StoryLabel>xs</StoryLabel>
-      {createTabs({ rootProps: { size: 'xs' } })}
-    </div>
+      <StoryLabel>forceMount</StoryLabel>
 
-    <div>
-      <StoryLabel>sm</StoryLabel>
-      {createTabs({ rootProps: { size: 'sm' } })}
-    </div>
+      <Tabs defaultValue="tab1" forceMount>
+        <Tabs.List>
+          {tabs.map(({ value, children, disabled }) => (
+            <Tabs.Trigger key={value} value={value} disabled={disabled}>
+              {children}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
 
-    <div>
-      <StoryLabel>md (default)</StoryLabel>
-      {createTabs({ rootProps: { size: 'md' } })}
+        {tabs.map(({ content, value }) => (
+          <Tabs.Content key={value} value={value}>
+            <p>{content}</p>
+          </Tabs.Content>
+        ))}
+      </Tabs>
     </div>
-  </div>
-)
+  )
+}
 
-export const ForceMount: StoryFn = _args => (
-  <div>
-    <StoryLabel>forceMount</StoryLabel>
-    {createTabs({
-      rootProps: { defaultValue: 'tab1', forceMount: true },
-      tabs: defaultTabs,
-    })}
-  </div>
-)
+export const Disabled: StoryFn = _args => {
+  const tabs = [
+    {
+      children: <span>Inbox</span>,
+      value: 'tab1',
+      content: 'Your inbox is empty',
+      disabled: true,
+    },
+    {
+      children: <span>Today</span>,
+      value: 'tab2',
+      content: 'Make some coffee',
+      disabled: false,
+    },
+    {
+      children: <span>Upcoming</span>,
+      value: 'tab3',
+      content: 'Order more coffee',
+      disabled: false,
+    },
+  ]
 
-export const State: StoryFn = _args => (
-  <div className="gap-lg flex flex-row">
-    <div className="shrink basis-auto overflow-auto">
-      {createTabs({
-        rootProps: { defaultValue: 'tab2' },
-        tabs: [
-          {
-            children: <span>Inbox</span>,
-            value: 'tab1',
-            content: 'Your inbox is empty',
-            disabled: true,
-          },
-          {
-            children: <span>Today</span>,
-            value: 'tab2',
-            content: 'Make some coffee',
-            disabled: false,
-          },
-          {
-            children: <span>Upcoming</span>,
-            value: 'tab3',
-            content: 'Order more coffee',
-            disabled: false,
-          },
-        ],
-      })}
+  return (
+    <div className="gap-lg flex flex-row">
+      <div className="shrink basis-auto overflow-auto">
+        <Tabs defaultValue="tab2">
+          <Tabs.List>
+            {tabs.map(({ value, children, disabled }) => (
+              <Tabs.Trigger key={value} value={value} disabled={disabled}>
+                {children}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+
+          {tabs.map(({ content, value }) => (
+            <Tabs.Content key={value} value={value}>
+              <p>{content}</p>
+            </Tabs.Content>
+          ))}
+        </Tabs>
+      </div>
     </div>
-  </div>
-)
+  )
+}

--- a/packages/components/src/tabs/Tabs.test.tsx
+++ b/packages/components/src/tabs/Tabs.test.tsx
@@ -3,9 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { mockResizeObserver } from 'jsdom-testing-mocks'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createTabs, type TabItem } from './Tabs.stories'
+import { Tabs, TabsListProps, TabsProps } from '.'
+import { type TabItem } from './Tabs.stories'
 
-const tabs: TabItem[] = [
+const defaultTabs: TabItem[] = [
   {
     children: 'Yesterday',
     value: 'tab1',
@@ -28,6 +29,34 @@ const tabsWithOverflow = [
   { children: 'Seven', value: 'tab7', content: 'Lorem ipsum dolor sit amet' },
 ]
 
+const createTabs = ({
+  rootProps = {},
+  listProps = {},
+  tabs = defaultTabs,
+}: {
+  rootProps?: TabsProps
+  listProps?: Omit<TabsListProps, 'children'>
+  tabs?: TabItem[]
+} = {}) => {
+  return (
+    <Tabs defaultValue="tab1" {...rootProps}>
+      <Tabs.List {...listProps}>
+        {tabs.map(({ value, children, disabled, a11yLabel }) => (
+          <Tabs.Trigger key={value} value={value} disabled={disabled} aria-label={a11yLabel}>
+            {children}
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+
+      {tabs.map(({ content, value }) => (
+        <Tabs.Content key={value} value={value}>
+          <p>{content}</p>
+        </Tabs.Content>
+      ))}
+    </Tabs>
+  )
+}
+
 describe('Tabs', () => {
   const scrollIntoViewSpy = vi.fn()
 
@@ -44,7 +73,7 @@ describe('Tabs', () => {
     const user = userEvent.setup()
     const rootProps = { defaultValue: 'tab1', onValueChange: vi.fn() }
 
-    render(createTabs({ tabs, rootProps }))
+    render(createTabs({ rootProps }))
 
     expect(screen.getByText('Yesterday')).toBeInTheDocument()
 
@@ -57,7 +86,7 @@ describe('Tabs', () => {
   it('should scroll into focused tab item', async () => {
     const user = userEvent.setup()
 
-    render(createTabs({ tabs }))
+    render(createTabs())
 
     await user.click(screen.getByText('Today'))
 
@@ -68,7 +97,7 @@ describe('Tabs', () => {
     const user = userEvent.setup()
     const rootProps = { defaultValue: 'tab1', onValueChange: vi.fn() }
     const tabsWithDisabled = [
-      ...tabs,
+      ...defaultTabs,
       { children: 'Tomorrow', value: 'tab3', content: 'Things will happen', disabled: true },
     ]
 
@@ -213,7 +242,6 @@ describe('Tabs', () => {
       it('should keep inactive tabs in the DOM (but hidden) when forceMount prop is true', async () => {
         render(
           createTabs({
-            tabs,
             rootProps: { defaultValue: 'tab1', forceMount: true },
           })
         )

--- a/packages/components/src/tabs/TabsList.tsx
+++ b/packages/components/src/tabs/TabsList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { ArrowVerticalLeft } from '@spark-ui/icons/ArrowVerticalLeft'
 import { ArrowVerticalRight } from '@spark-ui/icons/ArrowVerticalRight'
 import { Tabs as RadixTabs } from 'radix-ui'


### PR DESCRIPTION
### Description, Motivation and Context

- streamlined stories for `Tabs` (some code was shared between stories)
- disabled `aria-live="polite"` on the `Carousel` when it has multiple slides per page.
- removed `aria-haspopup` from combobox (inherited from the `Popover`, it is already implicit with the `combobox` role and makes things too verbose when using a screen reader)
- updated `Combobox.Empty` to be a `li` instead of a `div` as the HTML markup was invalid.


### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 🧾 Documentation
