### PR TITLE
fix(components): update overlay color for dialogs

### DIFF
--- a/packages/components/src/dialog/DialogOverlay.tsx
+++ b/packages/components/src/dialog/DialogOverlay.tsx
@@ -17,7 +17,7 @@ export const Overlay = ({ className, ref, ...rest }: OverlayProps): ReactElement
       className={cx(
         isFullScreen ? 'hidden' : 'fixed',
         ['top-0', 'left-0', 'w-screen', 'h-screen', 'z-overlay'],
-        ['bg-overlay/dim-3'],
+        ['bg-overlay/dim-1'],
         ['data-[state=open]:animate-fade-in'],
         ['data-[state=closed]:animate-fade-out'],
         className

--- a/packages/components/src/drawer/DrawerOverlay.tsx
+++ b/packages/components/src/drawer/DrawerOverlay.tsx
@@ -11,7 +11,7 @@ export const DrawerOverlay = ({ className, ref, ...rest }: DrawerOverlayProps): 
     ref={ref}
     className={cx(
       ['fixed', 'top-0', 'left-0', 'w-screen', 'h-screen', 'z-overlay'],
-      ['bg-overlay/dim-3'],
+      ['bg-overlay/dim-1'],
       ['data-[state=open]:animate-fade-in'],
       ['data-[state=closed]:animate-fade-out'],
       className

--- a/packages/utils/theme/src/dark-theme.css
+++ b/packages/utils/theme/src/dark-theme.css
@@ -74,7 +74,7 @@
   --color-surface-inverse-hovered: #f0f2f5;
   --color-outline: #6c819d;
   --color-outline-high: #f0f2f5;
-  --color-overlay: #2b3441;
+  --color-overlay: #3a4757;
   --color-on-overlay: #f6f8f9;
   --color-shadow: rgba(0 0 0 / 0.5);
 }


### PR DESCRIPTION
### Description, Motivation and Context

Two updates to improve contrast of overlay for `Dialog` and `Drawer` components:
- update the color token for the dark theme.
- fixed the opacity applied to the overlay color (`dim-3` -> `dim-1`)

### Types of changes
- [x] 💄 Styles

### Screenshots - Animations
![dark](https://github.com/user-attachments/assets/f7ae387a-2580-43b1-87f8-317617a06972)
![light](https://github.com/user-attachments/assets/4360c6d3-c03c-46fe-b5eb-828d70d55be3)

