### PR TITLE
fix(components): reverting combobox a11y to investigate why it impact…

### DIFF
--- a/packages/components/src/combobox/ComboboxEmpty.tsx
+++ b/packages/components/src/combobox/ComboboxEmpty.tsx
@@ -6,7 +6,7 @@ import { useComboboxContext } from './ComboboxContext'
 interface EmptyProps {
   className?: string
   children: ReactNode
-  ref?: Ref<HTMLLIElement>
+  ref?: Ref<HTMLDivElement>
 }
 
 export const Empty = ({ className, children, ref: forwardedRef }: EmptyProps) => {
@@ -14,14 +14,12 @@ export const Empty = ({ className, children, ref: forwardedRef }: EmptyProps) =>
   const hasNoItemVisible = ctx.filteredItemsMap.size === 0
 
   return hasNoItemVisible ? (
-    <li
+    <div
       ref={forwardedRef}
-      role="option"
-      aria-selected={false}
       className={cx('px-lg py-md text-body-1 text-on-surface/dim-1', className)}
     >
       {children}
-    </li>
+    </div>
   ) : null
 }
 

--- a/packages/components/src/combobox/ComboboxInput.tsx
+++ b/packages/components/src/combobox/ComboboxInput.tsx
@@ -64,7 +64,6 @@ export const Input = ({
     ? {
         asChild: true,
         type: undefined,
-        'aria-haspopup': undefined,
       }
     : {}
 


### PR DESCRIPTION
…s ARIA role in cypress env


### Description, Motivation and Context

These changes breaks some cypress tests on consumers repositories, but only in CI envs, not locally.

I need time to investigate how the changes impact the aria roles in a virtual dom env.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)

