### PR TITLE
feat(components): formfield chars count now support screen readers

### DIFF
--- a/packages/components/src/form-field/FormField.doc.mdx
+++ b/packages/components/src/form-field/FormField.doc.mdx
@@ -49,6 +49,14 @@ export default () => (
 
 Use `FormField.CharactersCount` to show users how many characters they have left. Can be used in combination with all types of text inputs.
 
+<Callout kind="warning" className="sb-unstyled">
+  Don't forget to pass both `description` and `liveAnnouncement` props to the `FormField.CharactersCount` component to make it compatible with screen readers:
+  <ul className="pl-3xl">
+    <li className='list-disc'>`description` is read when the focus is on the input.</li>
+    <li className='list-disc'>`liveAnnouncement` is read when the user types (after a delay).</li>
+  </ul>
+</Callout>
+
 <Canvas of={stories.CharactersCount} />
 
 ### Required

--- a/packages/components/src/form-field/FormField.stories.tsx
+++ b/packages/components/src/form-field/FormField.stories.tsx
@@ -161,7 +161,7 @@ export const State: StoryFn = () => (
   </div>
 )
 
-export const CharactersCount: StoryFn = _args => {
+export const CharactersCount: StoryFn = () => {
   const MAX_LENGTH = 90
   const [value, setValue] = useState('')
 
@@ -171,7 +171,7 @@ export const CharactersCount: StoryFn = _args => {
 
   return (
     <FormField name="input-with-a-characters-count">
-      <FormField.Label>Input with a characters count</FormField.Label>
+      <FormField.Label>Email</FormField.Label>
 
       <FormField.Control>
         {({ id, name, description }) => (
@@ -189,11 +189,14 @@ export const CharactersCount: StoryFn = _args => {
       </FormField.Control>
 
       <div className="gap-md flex justify-between">
-        <FormField.HelperMessage>
-          Type the text but take into account the max length
-        </FormField.HelperMessage>
-
-        <FormField.CharactersCount value={value} maxLength={MAX_LENGTH} />
+        <FormField.CharactersCount
+          value={value}
+          maxLength={MAX_LENGTH}
+          description={`You can enter up to ${MAX_LENGTH} characters`}
+          liveAnnouncement={({ remainingChars }) =>
+            `You have ${remainingChars} characters remaining`
+          }
+        />
       </div>
     </FormField>
   )

--- a/packages/components/src/input/Input.stories.tsx
+++ b/packages/components/src/input/Input.stories.tsx
@@ -427,11 +427,14 @@ export const FieldCharactersCount: StoryFn = _args => {
       <Input value={value} onChange={handleChange} maxLength={MAX_LENGTH} />
 
       <div className="gap-md flex justify-between">
-        <FormField.HelperMessage>
-          Type the text but take into account the max length
-        </FormField.HelperMessage>
-
-        <FormField.CharactersCount value={value} maxLength={MAX_LENGTH} />
+        <FormField.CharactersCount
+          value={value}
+          maxLength={MAX_LENGTH}
+          description={`You can enter up to ${MAX_LENGTH} characters`}
+          liveAnnouncement={({ remainingChars }) =>
+            `You have ${remainingChars} characters remaining`
+          }
+        />
       </div>
     </FormField>
   )

--- a/packages/components/src/textarea/Textarea.stories.tsx
+++ b/packages/components/src/textarea/Textarea.stories.tsx
@@ -208,7 +208,14 @@ export const FieldCharactersCount: StoryFn = () => {
           <FormField.ErrorMessage>The description is invalid</FormField.ErrorMessage>
         </div>
 
-        <FormField.CharactersCount value={value} maxLength={maxLength} />
+        <FormField.CharactersCount
+          value={value}
+          maxLength={maxLength}
+          description={`You can enter up to ${maxLength} characters`}
+          liveAnnouncement={({ remainingChars }) =>
+            `You have ${remainingChars} characters remaining`
+          }
+        />
       </div>
     </FormField>
   )


### PR DESCRIPTION
<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [SPA-650](https://jira.ets.mpi-internal.com/browse/SPA-650)

### Description, Motivation and Context

Added `description` and `liveAccouncement` props on `FormField.CharactersCount` for a better screen reader support.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)

