### PR TITLE
fix(theme-utils): css output was no longer named style.css

### DIFF
--- a/packages/utils/theme/vite.config.ts
+++ b/packages/utils/theme/vite.config.ts
@@ -1,5 +1,5 @@
-import path from 'path'
 import terser from '@rollup/plugin-terser'
+import path from 'path'
 import dts from 'vite-plugin-dts'
 
 const pkg = require(path.resolve(__dirname, './package.json'))
@@ -17,6 +17,7 @@ export default async () => {
         entry: 'src/index.ts',
         formats: ['es', 'cjs'],
         fileName: 'index',
+        cssFileName: 'style', // https://vite.dev/guide/migration#customize-css-output-file-name-in-library-mode
       },
       rollupOptions: {
         external: [...deps, ...devDeps],


### PR DESCRIPTION
### Description, Motivation and Context

Vite v6 migration renamed the css output from `style.css` to `index.css` which was breaking for spark usage:
```
@import './node_modules/@spark-ui/theme-utils/dist/style.css';
```

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
