### PR TITLE
docs(theme-utils): fixed invalid path for tailwind parsing in setup s…

### DIFF
--- a/documentation/using-spark/Setup.mdx
+++ b/documentation/using-spark/Setup.mdx
@@ -27,7 +27,7 @@ Navigate to your **Tailwind CSS configuration file** and refer to the example be
 
 @import './node_modules/@spark-ui/theme-utils/dist/style.css'; /* spark default theme */
 
-@source './node_modules/@spark-ui/**/*.{js,mjs}'; /* ensure that the Spark components are scanned */
+@source './node_modules/@spark-ui'; /* ensure that the Spark components are scanned */
 ```
 
 <div className="mt-md flex justify-end">


### PR DESCRIPTION
…ection

Closes #2678 

### Description, Motivation and Context

Since components have been bundled as a single package, the way for tailwind to parse the code must be updated


### Types of changes
- [x] 🧾 Documentation
