### PR TITLE
fix(components): forward props to ComboboxItem

### DIFF
--- a/packages/components/src/combobox/ComboboxItem.tsx
+++ b/packages/components/src/combobox/ComboboxItem.tsx
@@ -62,6 +62,7 @@ const ItemContent = ({
   value,
   children,
   ref: forwardedRef,
+  ...rest
 }: ItemProps) => {
   const ctx = useComboboxContext()
   const itemCtx = useComboboxItemContext()
@@ -91,6 +92,7 @@ const ItemContent = ({
       )}
       key={value}
       {...downshiftItemProps}
+      {...rest}
       aria-selected={itemCtx.isSelected}
       aria-labelledby={itemCtx.textId}
     >


### PR DESCRIPTION
Closes #2712 

### Description, Motivation and Context

Props were forwarded inside `Combobox.Item`, but only in the wrapper/context provider, not on the component underneath it, so the props were lost.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
