### PR TITLE
feat(theme-utils): high-contrast-mode

### DIFF
--- a/.storybook/ThemeProvider.tsx
+++ b/.storybook/ThemeProvider.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, useEffect, useState } from 'react'
+
+export const ThemeProvider = ({
+  children,
+  colorScheme,
+  highContrast,
+}: {
+  children: ReactNode
+  colorScheme: string
+  highContrast: string
+}) => {
+  const [systemColorScheme, setSystemColorScheme] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  )
+  const [systemHighContrast, setSystemHighContrast] = useState(
+    () => window.matchMedia('(prefers-contrast: more)').matches
+  )
+
+  useEffect(() => {
+    const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const contrastQuery = window.matchMedia('(prefers-contrast: more)')
+
+    const updateColorScheme = (e: MediaQueryListEvent) => {
+      setSystemColorScheme(e.matches ? 'dark' : 'light')
+    }
+
+    const updateHighContrast = (e: MediaQueryListEvent) => {
+      setSystemHighContrast(e.matches)
+    }
+
+    colorSchemeQuery.addEventListener('change', updateColorScheme)
+    contrastQuery.addEventListener('change', updateHighContrast)
+
+    return () => {
+      colorSchemeQuery.removeEventListener('change', updateColorScheme)
+      contrastQuery.removeEventListener('change', updateHighContrast)
+    }
+  }, [])
+
+  const finalColorScheme = colorScheme === 'system' ? systemColorScheme : colorScheme
+  const finalHighContrast = highContrast === 'system' ? systemHighContrast : highContrast === 'true'
+  const finalThemeKey = `${finalColorScheme}${finalHighContrast ? '-more-contrast' : ''}`
+
+  useEffect(() => {
+    const htmlElement = document.querySelector('html')
+    if (htmlElement) {
+      htmlElement.setAttribute('data-theme', finalThemeKey)
+    }
+  }, [finalThemeKey])
+
+  return <>{children}</>
+}

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -12,12 +12,14 @@
     font-family: var(--font-sans) !important;
   }
 
-  html[data-theme="light"] {
+  html[data-theme="light"],
+  html[data-theme="light-more-contrast"] {
     --color-code-block: #f5f5f6;
     --canvas-stripe: #f7f7f7;
   }
 
-  html[data-theme="dark"] {
+  html[data-theme="dark"],
+  html[data-theme="dark-more-contrast"] {
     --color-code-block: #f6f8f9;
     --canvas-stripe: #1e1e1e;
   }
@@ -36,10 +38,10 @@
     color: var(--color-on-background) !important;
   }
 
-  .sbdocs-wrapper #spark-doc-container > h2,
-  .sbdocs-wrapper #spark-doc-container > h3,
-  .sbdocs-wrapper #spark-doc-container > h4,
-  .sbdocs-wrapper #spark-doc-container > h5 {
+  .sbdocs-wrapper #spark-doc-container>h2,
+  .sbdocs-wrapper #spark-doc-container>h3,
+  .sbdocs-wrapper #spark-doc-container>h4,
+  .sbdocs-wrapper #spark-doc-container>h5 {
     color: var(--color-support) !important;
   }
 
@@ -52,13 +54,11 @@
   }
 
   .docs-story {
-    background: repeating-linear-gradient(
-      45deg,
-      var(--color-surface),
-      var(--color-surface) 5px,
-      var(--canvas-stripe) 5px,
-      var(--canvas-stripe) 10px
-    ) !important;
+    background: repeating-linear-gradient(45deg,
+        var(--color-surface),
+        var(--color-surface) 5px,
+        var(--canvas-stripe) 5px,
+        var(--canvas-stripe) 10px) !important;
   }
 
 
@@ -82,15 +82,15 @@
     width: 100%;
   }
 
-  #spark-doc-container > h1 {
+  #spark-doc-container>h1 {
     color: #ec5a13 !important;
     font-weight: 700 !important;
   }
 
-  #spark-doc-container > h2,
-  #spark-doc-container > h3,
-  #spark-doc-container > h4,
-  #spark-doc-container > h5 {
+  #spark-doc-container>h2,
+  #spark-doc-container>h3,
+  #spark-doc-container>h4,
+  #spark-doc-container>h5 {
     color: #094171 !important;
     font-weight: 700 !important;
   }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,12 +2,14 @@ import { DocsContainer, DocsContainerProps } from '@storybook/blocks'
 import { Icon } from '@spark-ui/components/icon'
 import { ShareExpand } from '@spark-ui/icons/ShareExpand'
 import { WarningOutline } from '@spark-ui/icons/WarningOutline'
+import React, { ReactNode, useEffect, useState } from 'react'
 
 import '../src/tailwind.css'
 import './sb-theming.css'
 
 import { ToC } from '@docs/helpers/ToC'
-import { ReactNode, useEffect, useState } from 'react'
+
+import { ThemeProvider } from './ThemeProvider'
 
 interface Props extends DocsContainerProps {
   children: ReactNode
@@ -44,22 +46,36 @@ const ExampleContainer = ({ children, ...props }: Props) => {
 
 const preview = {
   globalTypes: {
-    theme: {
-      name: 'Theme',
-      description: 'Set the color theme',
-      defaultValue: 'light',
+    colorScheme: {
+      name: 'Color scheme',
+      description: 'Set the color scheme',
+      defaultValue: 'system',
       toolbar: {
-        // show the theme name once selected in the toolbar
         dynamicTitle: true,
         items: [
-          { value: 'light', right: '⚪️', title: 'Light' },
-          { value: 'dark', right: '⚫️', title: 'Dark' },
+          { value: 'system', right: '⚙️', title: 'System color scheme' },
+          { value: 'light', right: '⚪️', title: 'Light (forced)' },
+          { value: 'dark', right: '⚫️', title: 'Dark (forced)' },
+        ],
+      },
+    },
+    highContrast: {
+      name: 'a11y - High contrast',
+      description: 'Toggle high contrast',
+      defaultValue: 'system',
+      toolbar: {
+        dynamicTitle: true,
+        items: [
+          { value: 'system', right: '⚙️', title: 'System contrast' },
+          { value: 'false', title: 'Regular contrast (forced)' },
+          { value: 'true', title: 'High contrast (forced)' },
         ],
       },
     },
   },
   initialGlobals: {
-    theme: 'light',
+    colorScheme: 'system',
+    highContrast: 'system',
   },
   parameters: {
     docs: {
@@ -94,15 +110,16 @@ const preview = {
     },
   },
   decorators: [
-    // custom theme decorator, see https://yannbraga.dev/blog/multi-theme-decorator
-    (storyFn: () => ReactNode, { globals }: { globals: { theme: string } }) => {
-      const themeKey = globals.theme
-
-      const htmlElement = document.querySelector('html')
-      if (!htmlElement) return
-      htmlElement.setAttribute('data-theme', themeKey)
-
-      return storyFn()
+    (
+      storyFn: () => ReactNode,
+      { globals }: { globals: { colorScheme: string; highContrast: string } }
+    ) => {
+      const { colorScheme, highContrast } = globals
+      return (
+        <ThemeProvider colorScheme={colorScheme} highContrast={highContrast}>
+          {storyFn()}
+        </ThemeProvider>
+      )
     },
     (storyFn: () => ReactNode, { id, viewMode }: { id: string; viewMode: string }) => {
       const params = new URLSearchParams(window.top?.location.search)

--- a/packages/utils/theme/src/dark-theme-more-contrast.css
+++ b/packages/utils/theme/src/dark-theme-more-contrast.css
@@ -1,0 +1,92 @@
+[data-theme='dark-more-contrast'] {
+  --color-basic: #bcbcbc;
+  --color-on-basic: #1a1a1a;
+  --color-basic-hovered: #8d8d8d;
+  --color-basic-container: #4c4c4c;
+  --color-on-basic-container: #f9f9f9;
+  --color-basic-container-hovered: #303030;
+
+  --color-accent: #bcbcbc;
+  --color-on-accent: #1a1a1a;
+  --color-accent-hovered: #8d8d8d;
+  --color-accent-container: #4c4c4c;
+  --color-on-accent-container: #f9f9f9;
+  --color-accent-container-hovered: #303030;
+  --color-accent-variant: #bcbcbc;
+  --color-on-accent-variant: #1a1a1a;
+  --color-accent-variant-hovered: #8d8d8d;
+
+  --color-main: #bcbcbc;
+  --color-on-main: #1a1a1a;
+  --color-main-hovered: #8d8d8d;
+  --color-main-container: #4c4c4c;
+  --color-on-main-container: #f9f9f9;
+  --color-main-container-hovered: #303030;
+  --color-main-variant: #bcbcbc;
+  --color-on-main-variant: #1a1a1a;
+  --color-main-variant-hovered: #8d8d8d;
+
+  --color-support: #e6e6e6;
+  --color-on-support: #1a1a1a;
+  --color-support-hovered: #8d8d8d;
+  --color-support-container: #4c4c4c;
+  --color-on-support-container: #f9f9f9;
+  --color-support-container-hovered: #303030;
+  --color-support-variant: #bcbcbc;
+  --color-on-support-variant: #1a1a1a;
+  --color-support-variant-hovered: #8d8d8d;
+
+  --color-success: #bcbcbc;
+  --color-on-success: #1a1a1a;
+  --color-success-hovered: #8d8d8d;
+  --color-success-container: #4c4c4c;
+  --color-on-success-container: #f9f9f9;
+  --color-success-container-hovered: #303030;
+
+  --color-alert: #bcbcbc;
+  --color-on-alert: #1a1a1a;
+  --color-alert-hovered: #8d8d8d;
+  --color-alert-container: #4c4c4c;
+  --color-on-alert-container: #f9f9f9;
+  --color-alert-container-hovered: #303030;
+
+  --color-error: #bcbcbc;
+  --color-on-error: #1a1a1a;
+  --color-error-hovered: #8d8d8d;
+  --color-error-container: #4c4c4c;
+  --color-on-error-container: #f9f9f9;
+  --color-error-container-hovered: #303030;
+
+  --color-info: #bcbcbc;
+  --color-on-info: #1a1a1a;
+  --color-info-hovered: #8d8d8d;
+  --color-info-container: #4c4c4c;
+  --color-on-info-container: #f9f9f9;
+  --color-info-container-hovered: #303030;
+
+  --color-neutral: #bcbcbc;
+  --color-on-neutral: #1a1a1a;
+  --color-neutral-hovered: #8d8d8d;
+  --color-neutral-container: #4c4c4c;
+  --color-on-neutral-container: #f9f9f9;
+  --color-neutral-container-hovered: #303030;
+
+  --color-background: #2c2c2c;
+  --color-on-background: #f9f9f9;
+  --color-background-variant: #3c3c3c;
+  --color-on-background-variant: #f9f9f9;
+
+  --color-surface: #2c2c2c;
+  --color-on-surface: #f9f9f9;
+  --color-surface-hovered: #000000;
+  --color-surface-inverse: #f9f9f9;
+  --color-on-surface-inverse: #1a1a1a;
+  --color-surface-inverse-hovered: #e1e1e1;
+
+  --color-outline: #c1c1c1;
+  --color-outline-high: #f9f9f9;
+
+  --color-overlay: #1a1a1a;
+  --color-on-overlay: #f9f9f9;
+  --color-shadow: rgba(0 0 0 / 0.5);
+}

--- a/packages/utils/theme/src/light-theme-more-contrast.css
+++ b/packages/utils/theme/src/light-theme-more-contrast.css
@@ -1,0 +1,92 @@
+[data-theme='light-more-contrast'] {
+  --color-basic: #484848;
+  --color-on-basic: #f9f9f9;
+  --color-basic-hovered: #5e5e5e;
+  --color-basic-container: #e6e6e6;
+  --color-on-basic-container: #1a1a1a;
+  --color-basic-container-hovered: #f1f1f1;
+
+  --color-accent: #484848;
+  --color-on-accent: #f9f9f9;
+  --color-accent-hovered: #5e5e5e;
+  --color-accent-container: #e6e6e6;
+  --color-on-accent-container: #1a1a1a;
+  --color-accent-container-hovered: #f1f1f1;
+  --color-accent-variant: #484848;
+  --color-on-accent-variant: #f9f9f9;
+  --color-accent-variant-hovered: #5e5e5e;
+
+  --color-main: #484848;
+  --color-on-main: #f9f9f9;
+  --color-main-hovered: #5e5e5e;
+  --color-main-container: #e6e6e6;
+  --color-on-main-container: #1a1a1a;
+  --color-main-container-hovered: #f1f1f1;
+  --color-main-variant: #484848;
+  --color-on-main-variant: #f9f9f9;
+  --color-main-variant-hovered: #5e5e5e;
+
+  --color-support: #484848;
+  --color-on-support: #f9f9f9;
+  --color-support-hovered: #5e5e5e;
+  --color-support-container: #e6e6e6;
+  --color-on-support-container: #1a1a1a;
+  --color-support-container-hovered: #f1f1f1;
+  --color-support-variant: #484848;
+  --color-on-support-variant: #f9f9f9;
+  --color-support-variant-hovered: #5e5e5e;
+
+  --color-success: #484848;
+  --color-on-success: #f9f9f9;
+  --color-success-hovered: #5e5e5e;
+  --color-success-container: #e6e6e6;
+  --color-on-success-container: #1a1a1a;
+  --color-success-container-hovered: #f1f1f1;
+
+  --color-alert: #484848;
+  --color-on-alert: #f9f9f9;
+  --color-alert-hovered: #5e5e5e;
+  --color-alert-container: #e6e6e6;
+  --color-on-alert-container: #1a1a1a;
+  --color-alert-container-hovered: #f1f1f1;
+
+  --color-error: #484848;
+  --color-on-error: #f9f9f9;
+  --color-error-hovered: #5e5e5e;
+  --color-error-container: #e6e6e6;
+  --color-on-error-container: #1a1a1a;
+  --color-error-container-hovered: #f1f1f1;
+
+  --color-info: #484848;
+  --color-on-info: #f9f9f9;
+  --color-info-hovered: #5e5e5e;
+  --color-info-container: #e6e6e6;
+  --color-on-info-container: #1a1a1a;
+  --color-info-container-hovered: #f1f1f1;
+
+  --color-neutral: #484848;
+  --color-on-neutral: #f9f9f9;
+  --color-neutral-hovered: #5e5e5e;
+  --color-neutral-container: #e6e6e6;
+  --color-on-neutral-container: #1a1a1a;
+  --color-neutral-container-hovered: #f1f1f1;
+
+  --color-background: #f9f9f9;
+  --color-on-background: #1a1a1a;
+  --color-background-variant: #f2f2f2;
+  --color-on-background-variant: #1a1a1a;
+
+  --color-surface: #f9f9f9;
+  --color-on-surface: #1a1a1a;
+  --color-surface-hovered: #f9f9f9;
+  --color-surface-inverse: #1a1a1a;
+  --color-on-surface-inverse: #f9f9f9;
+  --color-surface-inverse-hovered: #f4f4f4;
+
+  --color-outline: #4f4f4f;
+  --color-outline-high: #000000;
+
+  --color-overlay: #1a1a1a;
+  --color-on-overlay: #f9f9f9;
+  --color-shadow: rgba(193, 193, 193, 0.5);
+}

--- a/packages/utils/theme/src/theme.css
+++ b/packages/utils/theme/src/theme.css
@@ -1,7 +1,10 @@
 @import './keyframes.css';
 @import './custom-variants.css';
 @import './utilities.css';
+
 @import './dark-theme.css';
+@import './light-theme-more-contrast.css';
+@import './dark-theme-more-contrast.css';
 
 @theme {
   --breakpoint-*: initial;


### PR DESCRIPTION
### Description, Motivation and Context

Introducing high contrast colors for Spark UI, for both light/dark color schemes.

Spark will now have 4 set of colors (themes) offered by default:

```
data-theme="light"
data-theme="light-more-contrast"
data-theme="dark"
data-theme="dark-more-contrast"
```

As light/dark have know contrast issues regarding some colors (ex: `main` color on light mode), the high contrast variant provides sufficient contrast to satisfy WCAG criterias.

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 💄 Styles

### Screenshots - Animations

https://github.com/user-attachments/assets/4104e9a0-0f06-4c50-88d2-89eb33aab6db


