### PR TITLE
fix(components): forward props to CarouselControls

### DIFF
--- a/packages/components/src/carousel/CarouselControls.tsx
+++ b/packages/components/src/carousel/CarouselControls.tsx
@@ -1,18 +1,23 @@
-import { ReactNode } from 'react'
+import { cx } from 'class-variance-authority'
+import { HTMLAttributes, ReactNode } from 'react'
 
 import { useCarouselContext } from './Carousel'
 
-interface ControlsProps {
+interface ControlsProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode
 }
 
-export const CarouselControls = ({ children }: ControlsProps) => {
+export const CarouselControls = ({ children, className, ...props }: ControlsProps) => {
   const ctx = useCarouselContext()
 
   return (
     <div
-      className="default:px-lg pointer-events-none absolute inset-0 flex flex-row items-center justify-between"
+      className={cx(
+        'default:px-lg pointer-events-none absolute inset-0 flex flex-row items-center justify-between',
+        className
+      )}
       {...ctx.getControlProps()}
+      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
Fixes #2732 

### Description, Motivation and Context

Forwarding `className` (and base html attributes) to `Carousel.Controls` to allow customization.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
