### PR TITLE
fix(theme-utils): invalid color tokens in high contrast mode

### DIFF
--- a/packages/utils/theme/src/dark-theme-more-contrast.css
+++ b/packages/utils/theme/src/dark-theme-more-contrast.css
@@ -26,7 +26,7 @@
   --color-on-main-variant: #1a1a1a;
   --color-main-variant-hovered: #8d8d8d;
 
-  --color-support: #e6e6e6;
+  --color-support: #bcbcbc;
   --color-on-support: #1a1a1a;
   --color-support-hovered: #8d8d8d;
   --color-support-container: #4c4c4c;

--- a/packages/utils/theme/src/light-theme-more-contrast.css
+++ b/packages/utils/theme/src/light-theme-more-contrast.css
@@ -81,7 +81,7 @@
   --color-surface-hovered: #f9f9f9;
   --color-surface-inverse: #1a1a1a;
   --color-on-surface-inverse: #f9f9f9;
-  --color-surface-inverse-hovered: #f4f4f4;
+  --color-surface-inverse-hovered: #3a3a3a;
 
   --color-outline: #4f4f4f;
   --color-outline-high: #000000;


### PR DESCRIPTION

<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [LBCSPARK-53](https://jira.ets.mpi-internal.com/browse/LBCSPARK-53)

### Description, Motivation and Context

The "support" intent in dark mode + high contrast appeared "lighter" than the others. This was an error since this is not the case in light mode. 

The "surface-inverse-hovered" in high contrast + light mode was not correct and almost the same color as on-surface-inverse (the text color), which made the text invisible on hover.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
