### PR TITLE
docs(components): new design for custom checkbox and radio example

### DIFF
--- a/packages/components/src/checkbox/Checkbox.doc.mdx
+++ b/packages/components/src/checkbox/Checkbox.doc.mdx
@@ -132,13 +132,6 @@ When implementing a custom checkbox, it is important to be careful to properly h
 
 <Canvas of={stories.CustomImplementation} />
 
-### Invisible checkbox
-
-We can go even further by completely hiding the checkbox using our [`VisuallyHidden`](?path=/docs/components-visuallyhidden--docs#visuallyhidden) component. This way, you end up with a component that shares all the intrinsic behaviors of a checkbox, but does not look like one.
-
-When implementing a custom checkbox, it is important to be careful to properly handle **accessibility (a11y) requirements**, as a11y considerations will not be handled behind the scenes as they would be when using a regular checkbox implementation
-
-<Canvas of={stories.InvisibleCheckbox} />
 
 ## Form field
 

--- a/packages/components/src/checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/checkbox/Checkbox.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { StoryLabel } from '@docs/helpers/StoryLabel'
 import { Close } from '@spark-ui/icons/Close'
 import { Plus } from '@spark-ui/icons/Plus'
@@ -31,7 +30,7 @@ export default meta
 export const Default: StoryFn = _args => (
   <Checkbox className="max-w-sz-432">
     Refuse terms and conditions, because you are so unhappy with it. There is no reason to accept
-    that, it’s unfair!
+    that, it's unfair!
   </Checkbox>
 )
 
@@ -112,7 +111,7 @@ export const Disabled: StoryFn = _args => <Checkbox disabled>Accept terms and co
 export const Reverse: StoryFn = _args => (
   <Checkbox reverse className="max-w-sz-432">
     Refuse terms and conditions, because you are so unhappy with it. There is no reason to accept
-    that, it’s unfair!
+    that, it's unfair!
   </Checkbox>
 )
 
@@ -221,13 +220,14 @@ export const CustomImplementation: StoryFn = () => {
         id={id}
         htmlFor={value}
         className={cx(
-          'max-w-sz-320 gap-md p-lg flex flex-wrap rounded-md shadow-sm',
-          checked ? 'bg-success/dim-4' : '',
+          'max-w-sz-320 bg-surface text-on-surface p-lg rounded-lg',
+          'gap-lg flex flex-wrap items-center',
+          checked ? 'ring-outline-high ring-2' : 'ring-outline ring-1',
           'cursor-pointer'
         )}
       >
         <Checkbox aria-labelledby={id} id={value} checked={checked} {...others} />
-        {children}
+        <div className="grow">{children}</div>
       </Label>
     )
   }
@@ -236,56 +236,6 @@ export const CustomImplementation: StoryFn = () => {
     const [checked, setChecked] = useState(['A'])
 
     const values = ['A', 'B', 'C']
-
-    return (
-      <CheckboxGroup value={checked} name="sport" onCheckedChange={setChecked}>
-        {values.map(value => {
-          return (
-            <CustomCheckbox key={value} value={value} checked={checked.includes(value)}>
-              <div className="flex grow justify-between">
-                <span className="font-bold">{value}</span>
-                <span>this is a custom</span>
-              </div>
-              <div className="w-full text-right italic">implementation of a checkbox</div>
-            </CustomCheckbox>
-          )
-        })}
-      </CheckboxGroup>
-    )
-  }
-
-  return <Example />
-}
-
-export const InvisibleCheckbox: StoryFn = () => {
-  const CustomCheckbox = ({ children, checked, ...others }: CheckboxProps) => {
-    const id = useId()
-    const { value } = others
-
-    return (
-      <Label
-        id={id}
-        htmlFor={value}
-        className={cx(
-          'max-w-sz-320 gap-md p-lg flex flex-wrap rounded-md shadow-sm',
-          checked ? 'bg-success/dim-3' : '',
-          'focus-within:ring-outline-high',
-          '[&:has(:focus-visible)]:focus-within:ring-2',
-          'cursor-pointer'
-        )}
-      >
-        <VisuallyHidden>
-          <Checkbox aria-labelledby={id} id={value} checked={checked} {...others} />
-        </VisuallyHidden>
-        {children}
-      </Label>
-    )
-  }
-
-  const Example = () => {
-    const [checked, setChecked] = useState(['D'])
-
-    const values = ['D', 'E', 'F']
 
     return (
       <CheckboxGroup value={checked} name="sport" onCheckedChange={setChecked}>

--- a/packages/components/src/radio-group/RadioGroup.doc.mdx
+++ b/packages/components/src/radio-group/RadioGroup.doc.mdx
@@ -83,14 +83,6 @@ When implementing a custom radio group, it is important to be careful to properl
 
 <Canvas of={stories.CustomImplementation} />
 
-### Invisible radio group
-
-We can go even further by completely hiding the radios using our [`VisuallyHidden`](?path=/docs/components-visuallyhidden--docs#visuallyhidden) component. This way, you end up with a component that shares all the intrinsic behaviors of a radio group, but does not look like one.
-
-When implementing a custom radio group, it is important to be careful to properly handle **accessibility (a11y) requirements**, as a11y considerations will not be handled behind the scenes as they would be when using a regular radio group implementation
-
-<Canvas of={stories.InvisibleRadioGroup} />
-
 ## Form field
 
 When using the `RadioGroup` component you might want to use it in combination with `FormField` to add a proper label, error message, etc.

--- a/packages/components/src/radio-group/RadioGroup.stories.tsx
+++ b/packages/components/src/radio-group/RadioGroup.stories.tsx
@@ -161,13 +161,14 @@ export const CustomImplementation: StoryFn = () => {
         id={id}
         htmlFor={value}
         className={cx(
-          'max-w-sz-320 gap-md p-lg flex flex-wrap rounded-md shadow-sm',
-          value === selectedValue ? 'bg-success/dim-4' : '',
+          'max-w-sz-320 bg-surface text-on-surface p-lg rounded-lg',
+          'gap-lg flex flex-wrap items-center',
+          value === selectedValue ? 'ring-outline-high ring-2' : 'ring-outline ring-1',
           'cursor-pointer'
         )}
       >
         <RadioGroup.Radio aria-labelledby={id} id={value} {...others} />
-        {children}
+        <div className="grow">{children}</div>
       </Label>
     )
   }
@@ -180,64 +181,6 @@ export const CustomImplementation: StoryFn = () => {
     }
 
     const radios = ['A', 'B', 'C']
-
-    return (
-      <RadioGroup value={value} name="sport" onValueChange={onValueChange}>
-        {radios.map(radio => {
-          return (
-            <CustomRadio selectedValue={value} key={radio} value={radio}>
-              <div className="flex grow justify-between">
-                <span className="font-bold">{radio}</span>
-                <span>this is a custom</span>
-              </div>
-              <div className="w-full text-right italic">implementation of a radio</div>
-            </CustomRadio>
-          )
-        })}
-      </RadioGroup>
-    )
-  }
-
-  return <Example />
-}
-
-export const InvisibleRadioGroup: StoryFn = () => {
-  const CustomRadio = ({
-    children,
-    selectedValue,
-    ...others
-  }: RadioProps & { selectedValue: string }) => {
-    const id = useId()
-    const { value } = others
-
-    return (
-      <Label
-        id={id}
-        htmlFor={value}
-        className={cx(
-          'max-w-sz-320 gap-md p-lg flex flex-wrap rounded-md shadow-sm',
-          value === selectedValue ? 'bg-success/dim-4' : '',
-          'cursor-pointer',
-          'focus-within:ring-outline-high',
-          '[&:has(:focus-visible)]:focus-within:ring-2'
-        )}
-      >
-        <VisuallyHidden>
-          <RadioGroup.Radio aria-labelledby={id} id={value} {...others} />
-        </VisuallyHidden>
-        {children}
-      </Label>
-    )
-  }
-
-  const Example = () => {
-    const [value, setValue] = useState<string>('')
-
-    function onValueChange(current: string) {
-      setValue(current)
-    }
-
-    const radios = ['D', 'E', 'F']
 
     return (
       <RadioGroup value={value} name="sport" onValueChange={onValueChange}>


### PR DESCRIPTION
Closes [LBCSPARK-261](https://jira.ets.mpi-internal.com/browse/LBCSPARK-261)
Closes [LBCSPARK-262](https://jira.ets.mpi-internal.com/browse/LBCSPARK-262)

### Description, Motivation and Context

UI suggested a new design/guideline for the custom radio/checkbox groups examples.

<img width="666" alt="Capture d’écran 2025-06-03 à 12 36 27" src="https://github.com/user-attachments/assets/8d36d13d-f63c-4014-8156-3eb6fc348bc5" />


### Types of changes
- [x] 🧾 Documentation
- [x] 💄 Styles

### Screenshots - Animations
![Capture d’écran 2025-06-03 à 17 16 24](https://github.com/user-attachments/assets/3b89e354-669e-4615-9952-8af2d07bd248)

