### PR TITLE
fix(components): update design checkbox

### DIFF
--- a/packages/components/src/checkbox/Checkbox.doc.mdx
+++ b/packages/components/src/checkbox/Checkbox.doc.mdx
@@ -80,20 +80,6 @@ Use the `disabled` prop to indicate that the checkbox is disabled.
 
 <Canvas of={stories.Disabled} />
 
-### Reverse
-
-<StoryLabel>Standalone</StoryLabel>
-
-Use the `reverse` prop if you want the label to be placed on the left side of the Checkbox
-
-<Canvas of={stories.Reverse} />
-
-<StoryLabel>Group</StoryLabel>
-
-Use the `reverse` prop if you want the label to be placed on the left side of the Checkbox
-
-<Canvas of={stories.ReverseGroup} />
-
 ### Icon
 
 Use `icon` prop to change the default checked icon.

--- a/packages/components/src/checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/checkbox/Checkbox.stories.tsx
@@ -108,32 +108,7 @@ export const ControlledGroup: StoryFn = () => {
 
 export const Disabled: StoryFn = _args => <Checkbox disabled>Accept terms and conditions</Checkbox>
 
-export const Reverse: StoryFn = _args => (
-  <Checkbox reverse className="max-w-sz-432">
-    Refuse terms and conditions, because you are so unhappy with it. There is no reason to accept
-    that, it's unfair!
-  </Checkbox>
-)
-
-export const ReverseGroup: StoryFn = _args => (
-  <CheckboxGroup className="max-w-sz-144" reverse name="sport">
-    <Checkbox value="soccer">Soccer</Checkbox>
-    <Checkbox value="tennis">Tennis</Checkbox>
-    <Checkbox value="baseball">Baseball</Checkbox>
-  </CheckboxGroup>
-)
-
-const intents = [
-  'main',
-  'support',
-  'accent',
-  'basic',
-  'success',
-  'alert',
-  'error',
-  'info',
-  'neutral',
-] as const
+const intents = ['basic', 'error'] as const
 
 export const Intent: StoryFn = _args => (
   <div className="gap-xl grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5">

--- a/packages/components/src/checkbox/CheckboxInput.styles.ts
+++ b/packages/components/src/checkbox/CheckboxInput.styles.ts
@@ -21,7 +21,6 @@ export const checkboxInputStyles = cva(
         main: [
           'text-on-main',
           'hover:ring-main-container',
-          // data-[ok=cool]:bg-main
           'data-[state=unchecked]:border-outline',
           'data-[state=indeterminate]:border-main data-[state=indeterminate]:bg-main',
           'data-[state=checked]:border-main data-[state=checked]:bg-main',
@@ -50,28 +49,28 @@ export const checkboxInputStyles = cva(
         success: [
           'text-on-success',
           'hover:ring-success-container',
-          'data-[state=unchecked]:border-outline',
+          'data-[state=unchecked]:border-success',
           'data-[state=indeterminate]:border-success data-[state=indeterminate]:bg-success',
           'data-[state=checked]:border-success data-[state=checked]:bg-success',
         ],
         alert: [
           'text-on-alert',
           'hover:ring-alert-container',
-          'data-[state=unchecked]:border-outline',
+          'data-[state=unchecked]:border-alert',
           'data-[state=indeterminate]:border-alert data-[state=indeterminate]:bg-alert',
           'data-[state=checked]:border-alert data-[state=checked]:bg-alert',
         ],
         error: [
           'text-on-error',
           'hover:ring-error-container',
-          'data-[state=unchecked]:border-outline',
+          'data-[state=unchecked]:border-error',
           'data-[state=indeterminate]:border-error data-[state=indeterminate]:bg-error',
           'data-[state=checked]:border-error data-[state=checked]:bg-error',
         ],
         info: [
           'text-on-info',
           'hover:ring-info-container',
-          'data-[state=unchecked]:border-outline',
+          'data-[state=unchecked]:border-info',
           'data-[state=indeterminate]:border-info data-[state=indeterminate]:bg-info',
           'data-[state=checked]:border-info data-[state=checked]:bg-info',
         ],

--- a/packages/components/src/radio-group/RadioGroup.doc.mdx
+++ b/packages/components/src/radio-group/RadioGroup.doc.mdx
@@ -55,11 +55,6 @@ Use `value` and `onValueChange` props to make the radio group controlled.
 
 <Canvas of={stories.DisabledItem} />
 
-### Reverse
-
-Use the `reverse` prop if you want the label to be placed on the left side of the Radio
-
-<Canvas of={stories.Reverse} />
 
 ### Intent
 

--- a/packages/components/src/radio-group/RadioGroup.stories.tsx
+++ b/packages/components/src/radio-group/RadioGroup.stories.tsx
@@ -73,25 +73,7 @@ export const Controlled: StoryFn = () => {
   )
 }
 
-export const Reverse: StoryFn = _args => (
-  <RadioGroup className="max-w-sz-112" reverse defaultValue="1">
-    <RadioGroup.Radio value="1">First</RadioGroup.Radio>
-    <RadioGroup.Radio value="2">Second</RadioGroup.Radio>
-    <RadioGroup.Radio value="3">Third</RadioGroup.Radio>
-  </RadioGroup>
-)
-
-const intents: RadioGroupProps['intent'][] = [
-  'main',
-  'support',
-  'accent',
-  'basic',
-  'info',
-  'neutral',
-  'success',
-  'alert',
-  'error',
-]
+const intents: RadioGroupProps['intent'][] = ['basic', 'error']
 
 export const Intent: StoryFn = _args => {
   return (

--- a/packages/components/src/radio-group/RadioInput.styles.ts
+++ b/packages/components/src/radio-group/RadioInput.styles.ts
@@ -43,22 +43,14 @@ export const radioInputVariants = cva(
           'data-[state=checked]:border-neutral',
           'hover:ring-neutral-container',
         ],
-        info: ['border-outline', 'data-[state=checked]:border-info', 'hover:ring-info-container'],
+        info: ['border-info', 'data-[state=checked]:border-info', 'hover:ring-info-container'],
         success: [
-          'border-outline',
+          'border-success',
           'data-[state=checked]:border-success',
           'hover:ring-success-container',
         ],
-        alert: [
-          'border-outline',
-          'data-[state=checked]:border-alert',
-          'hover:ring-alert-container',
-        ],
-        error: [
-          'border-outline',
-          'data-[state=checked]:border-error',
-          'hover:ring-error-container',
-        ],
+        alert: ['border-alert', 'data-[state=checked]:border-alert', 'hover:ring-alert-container'],
+        error: ['border-error', 'data-[state=checked]:border-error', 'hover:ring-error-container'],
       }),
     },
     defaultVariants: {


### PR DESCRIPTION
Closes JIRA [LBCSPARK-259](https://jira.ets.mpi-internal.com/browse/LBCSPARK-259)
Closes JIRA [LBCSPARK-260](https://jira.ets.mpi-internal.com/browse/LBCSPARK-260)

### Description, Motivation and Context

On both `Radio` and `Checkbox`:
- only `basic` and `error` intents remains documented (NOTE: the other intents are not removed to avoid a breaking change, but should no longer be used)
- `error` intent now display a red outline even in unchecked state (vs "outline" color before the changes)
- the `reverse` prop documentation has been removed, as for `a11y` this is not something we want to encourage.

### Types of changes
- [x] 🧾 Documentation
- [x] 💄 Styles

### Screenshots - Animations

![CHECKBOX](https://github.com/user-attachments/assets/10b9f125-6d75-4a94-bbfc-2f7acb24ce58)
![RADIO](https://github.com/user-attachments/assets/e68bbfb2-99dc-48ea-8c63-0647663026fe)

