### PR TITLE
Add missing data spark component attrs

### DIFF
--- a/documentation/references/Bookmark.mdx
+++ b/documentation/references/Bookmark.mdx
@@ -48,16 +48,16 @@ This bookmark will highlight all spark components on the current page.
                 return n
               }(e),
               s=l+1;
-              return r.style.zIndex=s,
+              r.style.zIndex=s,
               i.style.zIndex=s,
               o(e,r,i),
               document.body.appendChild(r),
-              document.body.appendChild(i),
-              {element:e,overlay:r,highlight:i}
+              document.body.appendChild(i);
+              return {element:e,overlay:r,highlight:i};
             }
             function o(e,t,n){
               const o=e.getBoundingClientRect();
-              t.style.top=o.top+window.scrollY+"px",
+              t.style.top=o.top+window.scrollY+o.height+"px",
               t.style.left=o.left+window.scrollX+"px",
               n.style.top=o.top+window.scrollY+"px",
               n.style.left=o.left+window.scrollX+"px",
@@ -65,7 +65,9 @@ This bookmark will highlight all spark components on the current page.
               n.style.height=o.height+"px"
             }
             function r(){
-              l.forEach((({element:e,overlay:t,highlight:n})=>{
+              l.forEach((item)=>{
+                if (!item) return;
+                const {element:e,overlay:t,highlight:n} = item;
                 if(document.body.contains(e))
                   o(e,t,n);
                 else{
@@ -74,18 +76,44 @@ This bookmark will highlight all spark components on the current page.
                   const o=l.findIndex((t=>t.element===e));
                   -1!==o&&l.splice(o,1)
                 }
-              }))
+              })
             }
             function i(){
-              l.forEach((({overlay:e,highlight:t})=>{
+              l.forEach((item)=>{
+                if (!item) return;
+                const {overlay:e,highlight:t} = item;
                 e.remove(),
                 t.remove()
-              })),
+              }),
               l.length=0,
               requestAnimationFrame((()=>{
+                // First pass: create all elements
+                const highlights = [];
                 document.querySelectorAll(\`[\${t}]\`).forEach((e=>{
-                  l.push(n(e))
-                }))
+                  const elements = n(e);
+                  highlights.push(elements);
+                  const showOverlay = () => {
+                    elements.overlay.style.opacity = '1';
+                    elements.overlay.style.display = 'block';
+                  };
+                  const hideOverlay = () => {
+                    elements.overlay.style.opacity = '0';
+                    elements.overlay.style.display = 'none';
+                  };
+                  e.addEventListener('mouseenter', showOverlay);
+                  e.addEventListener('mouseleave', hideOverlay);
+                }));
+
+                // Second pass: add all highlights first
+                highlights.forEach(elements => {
+                  document.body.appendChild(elements.highlight);
+                });
+
+                // Third pass: add all overlays
+                highlights.forEach(elements => {
+                  document.body.appendChild(elements.overlay);
+                  l.push(elements);
+                });
               }))
             }
             e.textContent=\`
@@ -97,11 +125,14 @@ This bookmark will highlight all spark components on the current page.
                 font-size: 12px;
                 font-weight: 700;
                 font-family: monospace;
-                z-index: 1;
+                z-index: 2;
                 pointer-events: none;
                 border-radius: 8px;
-                transform: translateY(-100%);
-                margin-top: -4px;
+                box-shadow: var(--shadow-sm, 0px 1px 2px 0px rgba(0, 0, 0, 0.05));
+                transform: translateY(0%);
+                margin-top: 4px;
+                opacity: 0;
+                transition: opacity 0.2s ease;
               }
               .spark-highlight {
                 position: absolute;

--- a/packages/components/src/avatar/AvatarAction.tsx
+++ b/packages/components/src/avatar/AvatarAction.tsx
@@ -39,6 +39,7 @@ export const AvatarAction = ({
 
   return (
     <Comp
+      data-spark-component="avatar-action"
       style={{
         position: 'absolute',
         ...(design === 'circle' ? { left: `${position.x}px`, top: `${position.y}px` } : {}),

--- a/packages/components/src/avatar/AvatarOnlineBadge.tsx
+++ b/packages/components/src/avatar/AvatarOnlineBadge.tsx
@@ -26,6 +26,7 @@ export const AvatarOnlineBadge = ({ angle = 135, ...props }: AvatarOnlineBadgePr
 
   return (
     <div
+      data-spark-component="avatar-online-badge"
       role="status"
       aria-label={onlineText}
       style={{

--- a/packages/components/src/carousel/Carousel.tsx
+++ b/packages/components/src/carousel/Carousel.tsx
@@ -46,6 +46,7 @@ export const Carousel = ({
       }}
     >
       <div
+        data-spark-component="carousel"
         className={cx('gap-lg relative box-border flex flex-col', className)}
         {...carouselApi.getRootProps()}
       >

--- a/packages/components/src/carousel/CarouselControls.tsx
+++ b/packages/components/src/carousel/CarouselControls.tsx
@@ -12,6 +12,7 @@ export const CarouselControls = ({ children, className, ...props }: ControlsProp
 
   return (
     <div
+      data-spark-component="carousel-controls"
       className={cx(
         'default:px-lg pointer-events-none absolute inset-0 flex flex-row items-center justify-between',
         className

--- a/packages/components/src/carousel/CarouselNextButton.tsx
+++ b/packages/components/src/carousel/CarouselNextButton.tsx
@@ -12,6 +12,7 @@ export const CarouselNextButton = ({
 
   return (
     <IconButton
+      data-spark-component="carousel-next-button"
       {...ctx.getNextTriggerProps()}
       intent="surface"
       design="filled"

--- a/packages/components/src/carousel/CarouselPageIndicator.tsx
+++ b/packages/components/src/carousel/CarouselPageIndicator.tsx
@@ -43,6 +43,7 @@ export const CarouselPageIndicator = ({
 
   return (
     <button
+      data-spark-component="carousel-page-indicator"
       ref={ref}
       key={index}
       {...ctx.getIndicatorProps({ index })}

--- a/packages/components/src/carousel/CarouselPagePicker.tsx
+++ b/packages/components/src/carousel/CarouselPagePicker.tsx
@@ -19,6 +19,7 @@ export const CarouselPagePicker = ({ children, className }: Props) => {
   return (
     <>
       <div
+        data-spark-component="carousel-page-picker"
         {...ctx.getIndicatorGroupProps()}
         className={cx(
           'default:min-h-sz-16 flex w-full flex-wrap items-center justify-center',

--- a/packages/components/src/carousel/CarouselPrevButton.tsx
+++ b/packages/components/src/carousel/CarouselPrevButton.tsx
@@ -12,6 +12,7 @@ export const CarouselPrevButton = ({
 
   return (
     <IconButton
+      data-spark-component="carousel-prev-button"
       {...ctx.getPrevTriggerProps()}
       intent="surface"
       design="filled"

--- a/packages/components/src/carousel/CarouselSlide.tsx
+++ b/packages/components/src/carousel/CarouselSlide.tsx
@@ -26,6 +26,7 @@ export const CarouselSlide = ({
 
   return (
     <div
+      data-spark-component="carousel-slide"
       ref={itemRef}
       {...ctx.getSlideProps({ index, totalSlides: totalSlides as number })}
       className={cx('default:bg-surface relative overflow-hidden', className)}

--- a/packages/components/src/carousel/CarouselSlides.tsx
+++ b/packages/components/src/carousel/CarouselSlides.tsx
@@ -16,6 +16,7 @@ export const CarouselSlides = ({ children, className = '' }: Props) => {
 
   return (
     <div
+      data-spark-component="carousel-slides"
       {...ctx.getSlidesContainerProps()}
       className={cx(
         'focus-visible:u-outline relative w-full',

--- a/packages/components/src/dialog/DialogBody.tsx
+++ b/packages/components/src/dialog/DialogBody.tsx
@@ -15,7 +15,12 @@ export const Body = ({
   ref,
   ...rest
 }: BodyProps): ReactElement => (
-  <div ref={ref} className={dialogBodyStyles({ inset, className })} {...rest}>
+  <div
+    data-spark-component="dialog-body"
+    ref={ref}
+    className={dialogBodyStyles({ inset, className })}
+    {...rest}
+  >
     {children}
   </div>
 )

--- a/packages/components/src/dialog/DialogCloseButton.tsx
+++ b/packages/components/src/dialog/DialogCloseButton.tsx
@@ -20,6 +20,7 @@ const Root = ({
 }: CloseButtonProps) => {
   return (
     <Close
+      data-spark-component="dialog-close-button"
       data-part="close"
       ref={ref}
       className={cx(['absolute', 'top-md', 'right-xl'], className)}

--- a/packages/components/src/dialog/DialogDescription.tsx
+++ b/packages/components/src/dialog/DialogDescription.tsx
@@ -5,6 +5,8 @@ export type DescriptionProps = RadixDialog.DialogDescriptionProps & {
   ref?: Ref<HTMLParagraphElement>
 }
 
-export const Description = (props: DescriptionProps) => <RadixDialog.Description {...props} />
+export const Description = (props: DescriptionProps) => (
+  <RadixDialog.Description data-spark-component="dialog-description" {...props} />
+)
 
 Description.displayName = 'Dialog.Description'

--- a/packages/components/src/dialog/DialogFooter.tsx
+++ b/packages/components/src/dialog/DialogFooter.tsx
@@ -8,7 +8,12 @@ export interface FooterProps {
 }
 
 export const Footer = ({ children, className, ref, ...rest }: FooterProps): ReactElement => (
-  <footer ref={ref} className={cx(className, ['px-xl', 'py-lg'])} {...rest}>
+  <footer
+    data-spark-component="dialog-footer"
+    ref={ref}
+    className={cx(className, ['px-xl', 'py-lg'])}
+    {...rest}
+  >
     {children}
   </footer>
 )

--- a/packages/components/src/dialog/DialogHeader.tsx
+++ b/packages/components/src/dialog/DialogHeader.tsx
@@ -8,7 +8,12 @@ export interface HeaderProps {
 }
 
 export const Header = ({ children, className, ref, ...rest }: HeaderProps): ReactElement => (
-  <header ref={ref} className={cx(className, ['px-xl', 'py-lg'])} {...rest}>
+  <header
+    data-spark-component="dialog-header"
+    ref={ref}
+    className={cx(className, ['px-xl', 'py-lg'])}
+    {...rest}
+  >
     {children}
   </header>
 )

--- a/packages/components/src/dialog/DialogOverlay.tsx
+++ b/packages/components/src/dialog/DialogOverlay.tsx
@@ -13,6 +13,7 @@ export const Overlay = ({ className, ref, ...rest }: OverlayProps): ReactElement
 
   return (
     <RadixDialog.Overlay
+      data-spark-component="dialog-overlay"
       ref={ref}
       className={cx(
         isFullScreen ? 'hidden' : 'fixed',

--- a/packages/components/src/dialog/DialogTitle.tsx
+++ b/packages/components/src/dialog/DialogTitle.tsx
@@ -9,6 +9,7 @@ export type TitleProps = RadixDialog.DialogTitleProps & {
 export const Title = ({ className, ref, ...others }: TitleProps) => {
   return (
     <RadixDialog.Title
+      data-spark-component="dialog-title"
       ref={ref}
       className={cx(
         'text-headline-1 text-on-surface',

--- a/packages/components/src/dialog/DialogTrigger.tsx
+++ b/packages/components/src/dialog/DialogTrigger.tsx
@@ -13,6 +13,8 @@ export interface TriggerProps {
   ref?: Ref<HTMLButtonElement>
 }
 
-export const Trigger = (props: TriggerProps): ReactElement => <RadixDialog.Trigger {...props} />
+export const Trigger = (props: TriggerProps): ReactElement => (
+  <RadixDialog.Trigger data-spark-component="dialog-trigger" {...props} />
+)
 
 Trigger.displayName = 'Dialog.Trigger'

--- a/packages/components/src/divider/DividerContent.tsx
+++ b/packages/components/src/divider/DividerContent.tsx
@@ -13,6 +13,7 @@ export interface DividerContentProps extends HTMLAttributes<HTMLSpanElement> {
 export const DividerContent = ({ children, ref, className, ...props }: DividerContentProps) => {
   return children ? (
     <span
+      data-spark-component="divider-content"
       ref={ref}
       {...props}
       className={cx('group-data-[writing-mode=vertical-lr]:[writing-mode:vertical-lr]', className)}

--- a/packages/components/src/drawer/DrawerBody.tsx
+++ b/packages/components/src/drawer/DrawerBody.tsx
@@ -15,7 +15,12 @@ export const DrawerBody = ({
   ref,
   ...rest
 }: DrawerBodyProps) => (
-  <div ref={ref} className={drawerBodyStyles({ inset, className })} {...rest}>
+  <div
+    data-spark-component="drawer-body"
+    ref={ref}
+    className={drawerBodyStyles({ inset, className })}
+    {...rest}
+  >
     {children}
   </div>
 )

--- a/packages/components/src/drawer/DrawerClose.tsx
+++ b/packages/components/src/drawer/DrawerClose.tsx
@@ -5,6 +5,8 @@ export type DrawerCloseProps = RadixDrawer.DialogCloseProps & {
   ref?: Ref<HTMLButtonElement>
 }
 
-export const DrawerClose = (props: DrawerCloseProps) => <RadixDrawer.Close {...props} />
+export const DrawerClose = (props: DrawerCloseProps) => (
+  <RadixDrawer.Close data-spark-component="drawer-close" {...props} />
+)
 
 DrawerClose.displayName = 'Drawer.Close'

--- a/packages/components/src/drawer/DrawerCloseButton.tsx
+++ b/packages/components/src/drawer/DrawerCloseButton.tsx
@@ -19,6 +19,7 @@ export const DrawerCloseButton = ({
   ...rest
 }: DrawerCloseButtonProps) => (
   <DrawerClose
+    data-spark-component="drawer-close-button"
     ref={ref}
     className={cx(['absolute', 'top-sm', 'right-xl'], className)}
     asChild

--- a/packages/components/src/drawer/DrawerDescription.tsx
+++ b/packages/components/src/drawer/DrawerDescription.tsx
@@ -6,7 +6,7 @@ export type DrawerDescriptionProps = RadixDrawer.DialogDescriptionProps & {
 }
 
 export const DrawerDescription = (props: DrawerDescriptionProps) => (
-  <RadixDrawer.Description {...props} />
+  <RadixDrawer.Description data-spark-component="drawer-description" {...props} />
 )
 
 DrawerDescription.displayName = 'Drawer.Description'

--- a/packages/components/src/drawer/DrawerFooter.tsx
+++ b/packages/components/src/drawer/DrawerFooter.tsx
@@ -6,7 +6,12 @@ export type DrawerFooterProps = ComponentPropsWithoutRef<'footer'> & {
 }
 
 export const DrawerFooter = ({ className, ref, ...rest }: DrawerFooterProps): ReactElement => (
-  <footer ref={ref} className={cx(['px-xl', 'py-lg'], className)} {...rest} />
+  <footer
+    data-spark-component="drawer-footer"
+    ref={ref}
+    className={cx(['px-xl', 'py-lg'], className)}
+    {...rest}
+  />
 )
 
 DrawerFooter.displayName = 'Drawer.Footer'

--- a/packages/components/src/drawer/DrawerHeader.tsx
+++ b/packages/components/src/drawer/DrawerHeader.tsx
@@ -13,7 +13,12 @@ export const DrawerHeader = ({
   ref,
   ...rest
 }: DrawerHeaderProps): ReactElement => (
-  <header ref={ref} className={cx(['px-xl', 'py-lg'], className)} {...rest}>
+  <header
+    data-spark-component="drawer-header"
+    ref={ref}
+    className={cx(['px-xl', 'py-lg'], className)}
+    {...rest}
+  >
     {children}
   </header>
 )

--- a/packages/components/src/drawer/DrawerOverlay.tsx
+++ b/packages/components/src/drawer/DrawerOverlay.tsx
@@ -8,6 +8,7 @@ export type DrawerOverlayProps = RadixDrawer.DialogOverlayProps & {
 
 export const DrawerOverlay = ({ className, ref, ...rest }: DrawerOverlayProps): ReactElement => (
   <RadixDrawer.Overlay
+    data-spark-component="drawer-overlay"
     ref={ref}
     className={cx(
       ['fixed', 'top-0', 'left-0', 'w-screen', 'h-screen', 'z-overlay'],

--- a/packages/components/src/drawer/DrawerTitle.tsx
+++ b/packages/components/src/drawer/DrawerTitle.tsx
@@ -8,6 +8,7 @@ export type DrawerTitleProps = RadixDrawer.DialogTitleProps & {
 
 export const DrawerTitle = ({ className, ref, ...others }: DrawerTitleProps) => (
   <RadixDrawer.Title
+    data-spark-component="drawer-title"
     ref={ref}
     className={cx('text-headline-2 text-on-surface', className)}
     {...others}

--- a/packages/components/src/drawer/DrawerTrigger.tsx
+++ b/packages/components/src/drawer/DrawerTrigger.tsx
@@ -10,7 +10,7 @@ export interface DrawerTriggerProps extends RadixDrawer.DialogTriggerProps {
 }
 
 export const DrawerTrigger = (props: DrawerTriggerProps): ReactElement => (
-  <RadixDrawer.Trigger {...props} />
+  <RadixDrawer.Trigger data-spark-component="drawer-trigger" {...props} />
 )
 
 DrawerTrigger.displayName = 'Drawer.Trigger'

--- a/packages/components/src/icon-button/IconButton.tsx
+++ b/packages/components/src/icon-button/IconButton.tsx
@@ -20,6 +20,7 @@ export const IconButton = ({
 }: IconButtonProps) => {
   return (
     <Button
+      data-spark-component="icon-button"
       ref={ref}
       className={iconButtonStyles({ size, className })}
       design={design}

--- a/packages/components/src/input/Input.tsx
+++ b/packages/components/src/input/Input.tsx
@@ -63,6 +63,7 @@ const Root = ({
 
   return (
     <Component
+      data-spark-component="input"
       ref={ref}
       id={id}
       name={name}

--- a/packages/components/src/input/InputAddon.tsx
+++ b/packages/components/src/input/InputAddon.tsx
@@ -35,6 +35,7 @@ export const InputAddon = ({
   return (
     <Component
       ref={ref}
+      data-spark-component="input-addon"
       className={inputAddonStyles({
         className,
         intent: state,

--- a/packages/components/src/input/InputClearButton.tsx
+++ b/packages/components/src/input/InputClearButton.tsx
@@ -34,6 +34,7 @@ const Root = ({
   return (
     <button
       ref={ref}
+      data-spark-component="input-clear-button"
       className={cx(
         className,
         'pointer-events-auto absolute',

--- a/packages/components/src/input/InputGroup.tsx
+++ b/packages/components/src/input/InputGroup.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable complexity */
+/* eslint-disable max-lines-per-function */
 
 import { useFormFieldControl } from '@spark-ui/components/form-field'
 import { useCombinedState } from '@spark-ui/hooks/use-combined-state'
@@ -138,6 +138,7 @@ export const InputGroup = ({
   return (
     <InputGroupContext.Provider value={current}>
       <div
+        data-spark-component="input-group"
         ref={forwardedRef}
         className={inputGroupStyles({ disabled, readOnly, className })}
         {...others}

--- a/packages/components/src/input/InputIcon.tsx
+++ b/packages/components/src/input/InputIcon.tsx
@@ -11,6 +11,7 @@ export const InputIcon = ({ className, intent, children, ...others }: InputIconP
 
   return (
     <Icon
+      data-spark-component="input-icon"
       intent={intent}
       className={cx(
         className,

--- a/packages/components/src/kbd/Kbd.tsx
+++ b/packages/components/src/kbd/Kbd.tsx
@@ -7,6 +7,7 @@ export type KbdProps = ComponentPropsWithoutRef<'div'> & {
 export const Kbd = ({ className, ref, ...props }: PropsWithChildren<KbdProps>) => {
   return (
     <kbd
+      data-spark-component="kbd"
       ref={ref}
       className={[
         'border-sm border-b-md border-outline bg-neutral-container pe-md ps-md text-caption rounded-sm font-mono leading-4 font-bold whitespace-nowrap',

--- a/packages/components/src/progress-tracker/ProgressTrackerStep.tsx
+++ b/packages/components/src/progress-tracker/ProgressTrackerStep.tsx
@@ -75,6 +75,7 @@ export const ProgressTrackerStep = ({
 
   return (
     <li
+      data-spark-component="progress-tracker-step"
       id={stepId}
       ref={ref}
       data-state={progressState}

--- a/packages/components/src/progress/Progress.tsx
+++ b/packages/components/src/progress/Progress.tsx
@@ -34,6 +34,7 @@ export const Progress = ({
   return (
     <ProgressContext.Provider data-spark-component="progress" value={value}>
       <RadixProgress.Progress
+        data-spark-component="progress"
         ref={ref}
         className={cx('gap-sm focus-visible:u-outline flex flex-col', className)}
         value={valueProp}

--- a/packages/components/src/progress/ProgressBar.tsx
+++ b/packages/components/src/progress/ProgressBar.tsx
@@ -15,7 +15,12 @@ export const ProgressBar = ({
   const { shape } = useProgress()
 
   return (
-    <div className={progressBarStyles({ className, shape })} ref={ref} {...others}>
+    <div
+      data-spark-component="progress-bar"
+      className={progressBarStyles({ className, shape })}
+      ref={ref}
+      {...others}
+    >
       {children}
     </div>
   )

--- a/packages/components/src/progress/ProgressIndicator.tsx
+++ b/packages/components/src/progress/ProgressIndicator.tsx
@@ -17,6 +17,7 @@ export const ProgressIndicator = ({
 
   return (
     <RadixProgress.ProgressIndicator
+      data-spark-component="progress-indicator"
       className={progressIndicatorStyles({ className, intent, shape, isIndeterminate })}
       style={{ ...style, ...(!isIndeterminate && { transform: `translateX(-${x}%)` }) }}
       ref={ref}

--- a/packages/components/src/progress/ProgressLabel.tsx
+++ b/packages/components/src/progress/ProgressLabel.tsx
@@ -24,7 +24,13 @@ export const ProgressLabel = ({
   const ref = useMergeRefs(forwardedRef, rootRef)
 
   return (
-    <span id={id} className="text-body-2 text-on-surface" ref={ref} {...others}>
+    <span
+      data-spark-component="progress-label"
+      id={id}
+      className="text-body-2 text-on-surface"
+      ref={ref}
+      {...others}
+    >
       {children}
     </span>
   )

--- a/packages/components/src/radio-group/RadioInput.tsx
+++ b/packages/components/src/radio-group/RadioInput.tsx
@@ -34,6 +34,7 @@ export const RadioInput = ({ intent: intentProp, className, ref, ...others }: Ra
 
   return (
     <RadixRadioGroup.RadioGroupItem
+      data-spark-component="radio-input"
       ref={ref}
       className={radioInputVariants({ intent, className })}
       {...others}

--- a/packages/components/src/radio-group/RadioLabel.tsx
+++ b/packages/components/src/radio-group/RadioLabel.tsx
@@ -21,7 +21,13 @@ export interface RadioLabelProps
 }
 
 export const RadioLabel = ({ disabled, ...others }: RadioLabelProps) => {
-  return <Label.Root className={radioLabelStyles({ disabled })} {...others} />
+  return (
+    <Label.Root
+      data-spark-component="radio-label"
+      className={radioLabelStyles({ disabled })}
+      {...others}
+    />
+  )
 }
 
 RadioLabel.displayName = 'RadioGroup.RadioLabel'

--- a/packages/components/src/rating/RatingStar.tsx
+++ b/packages/components/src/rating/RatingStar.tsx
@@ -30,6 +30,7 @@ export const RatingStar = ({
 }: RatingStarProps) => {
   return (
     <div
+      data-spark-component="rating-star"
       ref={forwardedRef}
       onMouseEnter={onMouseEnter}
       className={ratingStarStyles({

--- a/packages/components/src/scrolling-list/ScrollingList.tsx
+++ b/packages/components/src/scrolling-list/ScrollingList.tsx
@@ -103,7 +103,12 @@ export const ScrollingList = ({
 
   return (
     <ScrollingListContext.Provider value={ctxValue}>
-      <div className="gap-lg group/scrolling-list relative flex w-full flex-col">{children}</div>
+      <div
+        data-spark-component="scrolling-list"
+        className="gap-lg group/scrolling-list relative flex w-full flex-col"
+      >
+        {children}
+      </div>
       <span ref={skipAnchorRef} className="size-0 overflow-hidden" tabIndex={-1} />
     </ScrollingListContext.Provider>
   )

--- a/packages/components/src/scrolling-list/ScrollingListControls.tsx
+++ b/packages/components/src/scrolling-list/ScrollingListControls.tsx
@@ -22,6 +22,7 @@ export const ScrollingListControls = ({
 }: ScrollingListControls) => {
   return (
     <div
+      data-spark-component="scrolling-list-controls"
       className={cx(
         'default:px-md pointer-events-none absolute inset-0 flex flex-row items-center justify-between overflow-hidden',
         className

--- a/packages/components/src/scrolling-list/ScrollingListItem.tsx
+++ b/packages/components/src/scrolling-list/ScrollingListItem.tsx
@@ -36,6 +36,7 @@ export const ScrollingListItem = ({
 
   return (
     <Component
+      data-spark-component="scrolling-list-item"
       role="listitem"
       ref={itemRef}
       className={cx(

--- a/packages/components/src/scrolling-list/ScrollingListItems.tsx
+++ b/packages/components/src/scrolling-list/ScrollingListItems.tsx
@@ -87,6 +87,7 @@ export const ScrollingListItems = ({ children, className = '', ...rest }: Props)
 
   return (
     <div
+      data-spark-component="scrolling-list-items"
       id="scrolling-list-items"
       role="list"
       className={cx(

--- a/packages/components/src/scrolling-list/ScrollingListNextButton.tsx
+++ b/packages/components/src/scrolling-list/ScrollingListNextButton.tsx
@@ -22,6 +22,7 @@ export const ScrollingListNextButton = ({ 'aria-label': ariaLabel, ...rest }: Ic
 
   return (
     <IconButton
+      data-spark-component="scrolling-list-next-button"
       size="sm"
       intent="surface"
       design="filled"

--- a/packages/components/src/scrolling-list/ScrollingListPrevButton.tsx
+++ b/packages/components/src/scrolling-list/ScrollingListPrevButton.tsx
@@ -31,6 +31,7 @@ export const ScrollingListPrevButton = ({
 
   return (
     <IconButton
+      data-spark-component="scrolling-list-prev-button"
       size="sm"
       intent="surface"
       design="filled"

--- a/packages/components/src/slider/SliderThumb.tsx
+++ b/packages/components/src/slider/SliderThumb.tsx
@@ -39,6 +39,7 @@ export const SliderThumb = ({
 
   return (
     <RadixSlider.Thumb
+      data-spark-component="slider-thumb"
       ref={ref}
       asChild={asChild}
       onPointerDown={(e: PointerEvent<HTMLSpanElement>) => {

--- a/packages/components/src/slider/SliderTrack.tsx
+++ b/packages/components/src/slider/SliderTrack.tsx
@@ -19,7 +19,13 @@ export const SliderTrack = ({ asChild = false, className, ref, ...rest }: Slider
   const { intent, shape } = useSliderContext()
 
   return (
-    <RadixSlider.Track ref={ref} asChild={asChild} className={trackVariants({ shape })} {...rest}>
+    <RadixSlider.Track
+      data-spark-component="slider-track"
+      ref={ref}
+      asChild={asChild}
+      className={trackVariants({ shape })}
+      {...rest}
+    >
       <RadixSlider.Range className={rangeVariants({ intent, shape, className })} />
     </RadixSlider.Track>
   )

--- a/packages/components/src/snackbar/SnackbarItem.tsx
+++ b/packages/components/src/snackbar/SnackbarItem.tsx
@@ -1,4 +1,5 @@
-/* eslint-disable complexity */
+/* eslint-disable max-lines-per-function */
+
 import { useToast } from '@react-aria/toast'
 import {
   Children,
@@ -142,6 +143,7 @@ export const SnackbarItem = ({
 
   return (
     <div
+      data-spark-component="snackbar-item"
       className={snackbarItemVariant({ design, intent, className })}
       data-animation={toast.animation}
       {...(!(swipeState === 'cancel' && toast.animation === 'exiting') && {

--- a/packages/components/src/snackbar/SnackbarItemAction.tsx
+++ b/packages/components/src/snackbar/SnackbarItemAction.tsx
@@ -26,6 +26,7 @@ export const SnackbarItemAction = ({
 
   return (
     <Button
+      data-spark-component="snackbar-item-action"
       ref={ref}
       size="md"
       shape="rounded"

--- a/packages/components/src/snackbar/SnackbarItemClose.tsx
+++ b/packages/components/src/snackbar/SnackbarItemClose.tsx
@@ -28,6 +28,7 @@ export const SnackbarItemClose = ({
 
   return (
     <IconButton
+      data-spark-component="snackbar-item-close"
       ref={ref}
       size="md"
       shape="rounded"

--- a/packages/components/src/stepper/StepperButton.tsx
+++ b/packages/components/src/stepper/StepperButton.tsx
@@ -24,7 +24,7 @@ const IncrementButton = ({
   const { buttonProps } = useButton({ ...incrementButtonProps, ...rest }, ref)
 
   return (
-    <InputGroup.TrailingAddon asChild>
+    <InputGroup.TrailingAddon asChild data-spark-component="stepper-increment-button">
       <IconButton
         ref={ref}
         design={design}
@@ -59,7 +59,7 @@ const DecrementButton = ({
   const { buttonProps } = useButton({ ...decrementButtonProps, ...rest }, ref)
 
   return (
-    <InputGroup.LeadingAddon asChild>
+    <InputGroup.LeadingAddon asChild data-spark-component="stepper-decrement-button">
       <IconButton
         ref={ref}
         design={design}

--- a/packages/components/src/switch/SwitchInput.tsx
+++ b/packages/components/src/switch/SwitchInput.tsx
@@ -87,6 +87,7 @@ export const SwitchInput = ({
 
   return (
     <RadixSwitch.Root
+      data-spark-component="switch-input"
       ref={ref}
       className={styles({ intent, size, className })}
       value={value}

--- a/packages/components/src/switch/SwitchLabel.tsx
+++ b/packages/components/src/switch/SwitchLabel.tsx
@@ -17,5 +17,9 @@ export interface SwitchLabelProps extends LabelStylesProps, LabelProps {
 }
 
 export const SwitchLabel = ({ className, disabled, ...others }: SwitchLabelProps) => (
-  <Label className={labelStyles({ disabled, className })} {...others} />
+  <Label
+    data-spark-component="switch-label"
+    className={labelStyles({ disabled, className })}
+    {...others}
+  />
 )

--- a/packages/components/src/tabs/TabsContent.tsx
+++ b/packages/components/src/tabs/TabsContent.tsx
@@ -37,6 +37,7 @@ export const TabsContent = ({
 
   return (
     <RadixTabs.Content
+      data-spark-component="tabs-content"
       ref={ref}
       forceMount={forceMount || rest.forceMount}
       className={contentStyles({ className, forceMount })}

--- a/packages/components/src/tabs/TabsList.tsx
+++ b/packages/components/src/tabs/TabsList.tsx
@@ -147,6 +147,7 @@ export const TabsList = ({
       )}
 
       <RadixTabs.List
+        data-spark-component="tabs-list"
         ref={listRef}
         className={listStyles()}
         asChild={asChild}

--- a/packages/components/src/tabs/TabsTrigger.tsx
+++ b/packages/components/src/tabs/TabsTrigger.tsx
@@ -46,6 +46,7 @@ export const TabsTrigger = ({
 
   return (
     <RadixTabs.Trigger
+      data-spark-component="tabs-trigger"
       ref={ref}
       className={triggerVariants({ intent, size, className })}
       asChild={asChild}

--- a/packages/components/src/text-link/TextLink.tsx
+++ b/packages/components/src/text-link/TextLink.tsx
@@ -61,6 +61,7 @@ export const TextLink = ({
 
   return (
     <Component
+      data-spark-component="text-link"
       ref={ref}
       className={textLinkStyles({ className, bold, intent, underline })}
       {...props}


### PR DESCRIPTION
### Description, Motivation and Context

- Added `data-spark-component` attribute on components where it was missing.
- Improved the bookmark that highlights Spark component on a webpage:
    - Position the tooltips below the components.
    -  Only reveal the tooltips upon hovering.

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)


### Screenshots - Animations
![Capture d’écran 2025-06-13 à 12 31 39](https://github.com/user-attachments/assets/bc70a41c-4948-408b-8c3d-6a5add6f65a9)


