### PR TITLE
fix(components): contrast improvements

### DIFF
--- a/packages/components/src/progress-tracker/ProgressTrackerStep.styles.ts
+++ b/packages/components/src/progress-tracker/ProgressTrackerStep.styles.ts
@@ -6,6 +6,8 @@ export const stepItemVariant = cva(
     // Progress Track
     'after:absolute after:z-base',
     'last:after:content-none',
+    'after:bg-outline',
+    'group-data-[orientation=horizontal]/list:before:bg-outline',
     // Horizontal orientation
     'group-data-[orientation=horizontal]/list:px-[1px]',
     'group-data-[orientation=horizontal]/list:before:absolute group-data-[orientation=horizontal]/list:before:z-base',
@@ -55,15 +57,15 @@ export const stepItemVariant = cva(
         ],
       },
       intent: {
-        basic: ['after:bg-basic', 'group-data-[orientation=horizontal]/list:before:bg-basic'],
-        support: ['after:bg-support', 'group-data-[orientation=horizontal]/list:before:bg-support'],
-        main: ['after:bg-main', 'group-data-[orientation=horizontal]/list:before:bg-main'],
-        neutral: ['after:bg-neutral', 'group-data-[orientation=horizontal]/list:before:bg-neutral'],
-        info: ['after:bg-info', 'group-data-[orientation=horizontal]/list:before:bg-info'],
-        accent: ['after:bg-accent', 'group-data-[orientation=horizontal]/list:before:bg-accent'],
-        danger: ['after:bg-error', 'group-data-[orientation=horizontal]/list:before:bg-error'],
-        alert: ['after:bg-alert', 'group-data-[orientation=horizontal]/list:before:bg-alert'],
-        success: ['after:bg-success', 'group-data-[orientation=horizontal]/list:before:bg-success'],
+        basic: '',
+        support: '',
+        main: '',
+        neutral: '',
+        info: '',
+        accent: '',
+        danger: '',
+        alert: '',
+        success: '',
       },
       disabled: {
         true: 'before:opacity-dim-3',

--- a/packages/components/src/progress-tracker/ProgressTrackerStepLabel.styles.ts
+++ b/packages/components/src/progress-tracker/ProgressTrackerStepLabel.styles.ts
@@ -1,9 +1,0 @@
-import { cva } from 'class-variance-authority'
-
-export const stepLabel = cva([
-  'flex text-body-2 font-bold',
-  'text-on-surface group-disabled/btn:text-on-surface/dim-1',
-  'group-data-[orientation=horizontal]/list:mt-md',
-  'group-data-[orientation=vertical]/list:ml-md',
-  'group-data-[orientation=vertical]/list:my-auto',
-])

--- a/packages/components/src/progress-tracker/ProgressTrackerStepLabel.tsx
+++ b/packages/components/src/progress-tracker/ProgressTrackerStepLabel.tsx
@@ -1,14 +1,38 @@
+import { cva } from 'class-variance-authority'
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 
-import { stepLabel } from './ProgressTrackerStepLabel.styles'
+import { useProgressTrackerStepContext } from './ProgressTrackerContext'
 
 type ProgressTrackerStepLabelProps = ComponentPropsWithoutRef<'span'> & {
   children: ReactNode
 }
 
+const stepLabel = cva(
+  [
+    'flex text-body-2 ',
+    'text-on-surface group-disabled/btn:text-on-surface/dim-1',
+    'group-data-[orientation=horizontal]/list:mt-md',
+    'group-data-[orientation=vertical]/list:ml-md',
+    'group-data-[orientation=vertical]/list:my-auto',
+  ],
+  {
+    variants: {
+      state: {
+        complete: '',
+        incomplete: '',
+        active: 'font-bold',
+      },
+    },
+  }
+)
+
 export const ProgressTrackerStepLabel = ({
   className,
   children,
-}: ProgressTrackerStepLabelProps) => <span className={stepLabel({ className })}>{children}</span>
+}: ProgressTrackerStepLabelProps) => {
+  const { state } = useProgressTrackerStepContext()
+
+  return <span className={stepLabel({ state, className })}>{children}</span>
+}
 
 ProgressTrackerStepLabel.displayName = 'ProgressTracker.StepLabel'

--- a/packages/components/src/progress-tracker/stepIndicatorVariants/outline.ts
+++ b/packages/components/src/progress-tracker/stepIndicatorVariants/outline.ts
@@ -13,7 +13,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'basic',
     state: 'active',
-    class: 'text-on-basic-container bg-basic-container',
+    class: 'text-on-basic bg-basic',
   },
   {
     design: 'outline',
@@ -29,7 +29,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'support',
     state: 'active',
-    class: 'text-on-support-container bg-support-container',
+    class: 'text-on-support bg-support',
   },
   {
     design: 'outline',
@@ -45,7 +45,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'main',
     state: 'active',
-    class: 'text-on-main-container bg-main-container',
+    class: 'text-on-main bg-main',
   },
   {
     design: 'outline',
@@ -61,7 +61,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'neutral',
     state: 'active',
-    class: 'text-on-neutral-container bg-neutral-container',
+    class: 'text-on-neutral bg-neutral',
   },
   {
     design: 'outline',
@@ -77,7 +77,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'info',
     state: 'active',
-    class: 'text-on-info-container bg-info-container',
+    class: 'text-on-info bg-info',
   },
   {
     design: 'outline',
@@ -93,7 +93,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'accent',
     state: 'active',
-    class: 'text-on-accent-container bg-accent-container',
+    class: 'text-on-accent bg-accent',
   },
   {
     design: 'outline',
@@ -109,7 +109,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'danger',
     state: 'active',
-    class: 'text-on-error-container bg-error-container',
+    class: 'text-on-error bg-error',
   },
   {
     design: 'outline',
@@ -125,7 +125,7 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'alert',
     state: 'active',
-    class: 'text-on-alert-container bg-alert-container',
+    class: 'text-on-alert bg-alert',
   },
   {
     design: 'outline',
@@ -141,6 +141,6 @@ export const outlineVariants = [
     design: 'outline',
     intent: 'success',
     state: 'active',
-    class: 'text-on-success-container bg-success-container',
+    class: 'text-on-success bg-success',
   },
 ] as const

--- a/packages/components/src/switch/Switch.doc.mdx
+++ b/packages/components/src/switch/Switch.doc.mdx
@@ -59,10 +59,6 @@ Use `checkedIcon` and `uncheckedIcon` props to change the default checked and un
 
 <Canvas of={stories.Icons} />
 
-### Intent
-
-<Canvas of={stories.Intent} />
-
 ### Sizes
 
 <Canvas of={stories.Sizes} />

--- a/packages/components/src/switch/Switch.stories.tsx
+++ b/packages/components/src/switch/Switch.stories.tsx
@@ -69,29 +69,6 @@ export const Sizes: StoryFn = _args => (
   </div>
 )
 
-const intents: ComponentProps<typeof Switch>['intent'][] = [
-  'main',
-  'support',
-  'accent',
-  'basic',
-  'success',
-  'alert',
-  'error',
-  'info',
-  'neutral',
-]
-
-export const Intent: StoryFn = _args => (
-  <div className="gap-lg flex">
-    {intents.map(intent => (
-      <div key={intent}>
-        <StoryLabel>{intent}</StoryLabel>
-        <Switch intent={intent} defaultChecked aria-label={`My ${intent} switch`} />
-      </div>
-    ))}
-  </div>
-)
-
 export const FieldHelperMessage: StoryFn = _args => (
   <FormField name="agreement">
     <Switch>Gifts only</Switch>

--- a/packages/components/src/switch/SwitchInput.styles.ts
+++ b/packages/components/src/switch/SwitchInput.styles.ts
@@ -10,7 +10,7 @@ export const styles = cva(
     'transition-colors duration-200 ease-in-out',
     'disabled:hover:ring-transparent disabled:cursor-not-allowed disabled:opacity-dim-3',
     'focus-visible:u-outline',
-    'data-[state=unchecked]:bg-on-surface/dim-4',
+    'data-[state=unchecked]:bg-on-surface/dim-3',
     'u-shadow-border-transition',
     'overflow-x-hidden',
   ]),
@@ -93,7 +93,7 @@ export const thumbStyles = cva(
       }),
       checked: {
         true: '-translate-x-full',
-        false: 'translate-x-0 text-on-surface/dim-4',
+        false: 'translate-x-0 text-on-surface/dim-2',
       },
     },
     defaultVariants: {

--- a/packages/components/src/tabs/TabsTrigger.styles.ts
+++ b/packages/components/src/tabs/TabsTrigger.styles.ts
@@ -8,6 +8,7 @@ export const triggerVariants = cva(
     'border-outline',
     'hover:not-disabled:bg-surface-hovered',
     'after:absolute',
+    'data-[state=active]:font-bold',
     'data-[state=inactive]:not-disabled:cursor-pointer',
     'data-[orientation=horizontal]:border-b-sm data-[orientation=horizontal]:after:inset-x-0 data-[orientation=horizontal]:after:bottom-[-1px] data-[orientation=horizontal]:after:h-sz-2',
     'data-[orientation=vertical]:border-r-sm data-[orientation=vertical]:after:inset-y-0 data-[orientation=vertical]:after:right-[-1px] data-[orientation=vertical]:after:w-sz-2',


### PR DESCRIPTION
## TYPE(SCOPE): TITLE

<!-- https://github.com/leboncoin/spark-web/issues -->

- Fixes [LBCSPARK-327](https://jira.ets.mpi-internal.com/browse/LBCSPARK-327)
- Fixes [LBCSPARK-333](https://jira.ets.mpi-internal.com/browse/LBCSPARK-333)
- Fixes [LBCSPARK-330](https://jira.ets.mpi-internal.com/browse/LBCSPARK-330)

### Description, Motivation and Context

- Switch: Improved contrast when unchecked (adjusted opacity of background and icon)
- ProgressTracker: 
    - Improved contrast of the active step for the `outline` design.
    - Line that links the step together is now using `outline` color token instead of various colors.
    - Text of the active step is now bold.
- Tabs: active tab trigger's text is now bold


### Types of changes
- [x] 💄 Styles

### Screenshots - Animations

before/after 
![Capture d’écran 2025-06-26 à 16 42 02](https://github.com/user-attachments/assets/92e7b067-897b-4d9e-9d06-2b8c6fa0966a)
![Capture d’écran 2025-06-26 à 16 42 27](https://github.com/user-attachments/assets/6edca6f8-a82c-40fa-a370-498f55570415)
![Capture d’écran 2025-06-26 à 16 41 12](https://github.com/user-attachments/assets/b709be67-bbd9-4651-952b-201dda24c5f7)


