### PR TITLE
style(components): use blue outline for input keyboard navigation

### DIFF
--- a/packages/components/src/combobox/ComboboxTrigger.styles.tsx
+++ b/packages/components/src/combobox/ComboboxTrigger.styles.tsx
@@ -5,7 +5,7 @@ export const styles = cva(
     'flex items-start gap-md min-h-sz-44 text-body-1',
     'h-fit rounded-lg px-lg',
     // outline styles
-    'ring-1 outline-hidden ring-inset focus-within:ring-2 focus-within:ring-blue',
+    'ring-1 outline-hidden ring-inset focus-within:ring-2 focus-within:ring-focus',
   ],
   {
     variants: {

--- a/packages/components/src/combobox/ComboboxTrigger.styles.tsx
+++ b/packages/components/src/combobox/ComboboxTrigger.styles.tsx
@@ -5,7 +5,7 @@ export const styles = cva(
     'flex items-start gap-md min-h-sz-44 text-body-1',
     'h-fit rounded-lg px-lg',
     // outline styles
-    'ring-1 outline-hidden ring-inset focus-within:ring-2',
+    'ring-1 outline-hidden ring-inset focus-within:ring-2 focus-within:ring-blue',
   ],
   {
     variants: {
@@ -14,7 +14,7 @@ export const styles = cva(
         false: 'h-sz-44',
       },
       state: {
-        undefined: 'ring-outline focus-within:ring-outline-high',
+        undefined: 'ring-outline',
         error: 'ring-error',
         alert: 'ring-alert',
         success: 'ring-success',
@@ -30,7 +30,7 @@ export const styles = cva(
       {
         disabled: false,
         state: undefined,
-        class: 'hover:ring-outline-high',
+        class: 'default:hover:ring-outline-high',
       },
       {
         disabled: false,

--- a/packages/components/src/dropdown/DropdownTrigger.styles.tsx
+++ b/packages/components/src/dropdown/DropdownTrigger.styles.tsx
@@ -6,7 +6,7 @@ export const styles = cva(
     'min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg',
     'text-body-1',
     // outline styles
-    'ring-1 outline-hidden ring-inset focus:ring-2 focus:ring-blue',
+    'ring-1 outline-hidden ring-inset focus:ring-2 focus:ring-focus',
   ],
   {
     variants: {

--- a/packages/components/src/dropdown/DropdownTrigger.styles.tsx
+++ b/packages/components/src/dropdown/DropdownTrigger.styles.tsx
@@ -6,12 +6,12 @@ export const styles = cva(
     'min-h-sz-44 rounded-lg bg-surface text-on-surface px-lg',
     'text-body-1',
     // outline styles
-    'ring-1 outline-hidden ring-inset focus:ring-2',
+    'ring-1 outline-hidden ring-inset focus:ring-2 focus:ring-blue',
   ],
   {
     variants: {
       state: {
-        undefined: 'ring-outline focus:ring-outline-high',
+        undefined: 'ring-outline',
         error: 'ring-error',
         alert: 'ring-alert',
         success: 'ring-success',
@@ -27,7 +27,7 @@ export const styles = cva(
       {
         disabled: false,
         state: undefined,
-        class: 'hover:ring-outline-high',
+        class: 'default:hover:ring-outline-high',
       },
     ],
   }

--- a/packages/components/src/input/Input.styles.ts
+++ b/packages/components/src/input/Input.styles.ts
@@ -14,7 +14,7 @@ export const inputStyles = cva(
     'autofill:shadow-surface autofill:shadow-[inset_0_0_0px_1000px]',
     'disabled:cursor-not-allowed disabled:border-outline disabled:bg-on-surface/dim-5 disabled:text-on-surface/dim-3',
     'read-only:cursor-default read-only:pointer-events-none read-only:bg-on-surface/dim-5',
-    'focus:ring-1 focus:ring-inset focus:ring-blue focus:border-blue',
+    'focus:ring-1 focus:ring-inset focus:ring-focus focus:border-focus',
   ],
   {
     variants: {

--- a/packages/components/src/input/Input.styles.ts
+++ b/packages/components/src/input/Input.styles.ts
@@ -14,7 +14,7 @@ export const inputStyles = cva(
     'autofill:shadow-surface autofill:shadow-[inset_0_0_0px_1000px]',
     'disabled:cursor-not-allowed disabled:border-outline disabled:bg-on-surface/dim-5 disabled:text-on-surface/dim-3',
     'read-only:cursor-default read-only:pointer-events-none read-only:bg-on-surface/dim-5',
-    'focus:ring-1 focus:ring-inset',
+    'focus:ring-1 focus:ring-inset focus:ring-blue focus:border-blue',
   ],
   {
     variants: {
@@ -29,14 +29,10 @@ export const inputStyles = cva(
        * Color scheme of the button.
        */
       intent: {
-        neutral: [
-          'border-outline',
-          'hover:border-outline-high',
-          'focus:ring-outline-high focus:border-outline-high',
-        ],
-        success: ['border-success', 'focus:ring-success'],
-        alert: ['border-alert', 'focus:ring-alert'],
-        error: ['border-error', 'focus:ring-error'],
+        neutral: ['border-outline', 'default:hover:border-outline-high'],
+        success: ['default:border-success'],
+        alert: ['default:border-alert'],
+        error: ['default:border-error'],
       },
       /**
        * Sets if there is an addon before the input text.

--- a/packages/components/src/select/SelectTrigger.styles.tsx
+++ b/packages/components/src/select/SelectTrigger.styles.tsx
@@ -6,7 +6,7 @@ export const styles = cva(
     'min-h-sz-44 rounded-lg px-lg',
     'text-body-1',
     // outline styles
-    'ring-1 outline-hidden ring-inset',
+    'ring-1 outline-hidden ring-inset focus-within:ring-blue',
   ],
   {
     variants: {
@@ -40,7 +40,7 @@ export const styles = cva(
       {
         disabled: false,
         state: undefined,
-        class: 'hover:ring-outline-high focus-within:ring-outline-high',
+        class: 'default:hover:ring-outline-high',
       },
     ],
   }

--- a/packages/components/src/select/SelectTrigger.styles.tsx
+++ b/packages/components/src/select/SelectTrigger.styles.tsx
@@ -6,7 +6,7 @@ export const styles = cva(
     'min-h-sz-44 rounded-lg px-lg',
     'text-body-1',
     // outline styles
-    'ring-1 outline-hidden ring-inset focus-within:ring-blue',
+    'ring-1 outline-hidden ring-inset focus-within:ring-focus',
   ],
   {
     variants: {

--- a/packages/components/src/slider/SliderThumb.styles.ts
+++ b/packages/components/src/slider/SliderThumb.styles.ts
@@ -4,7 +4,7 @@ export const thumbVariants = cva(
   [
     'block h-sz-24 w-sz-24 rounded-full cursor-pointer',
     'outline-hidden',
-    'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue',
+    'focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-focus',
     'data-[interaction=pointerdown]:focus-visible:ring-0!',
     'data-disabled:hover:ring-0 data-disabled:hover:after:w-0 data-disabled:hover:after:h-0 data-disabled:cursor-not-allowed',
     'after:absolute after:left-1/2 after:top-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:z-hide',

--- a/packages/utils/theme/src/dark-theme-more-contrast.css
+++ b/packages/utils/theme/src/dark-theme-more-contrast.css
@@ -1,4 +1,6 @@
 [data-theme='dark-more-contrast'] {
+  --color-focus: #d1d1ff;
+
   --color-basic: #bcbcbc;
   --color-on-basic: #1a1a1a;
   --color-basic-hovered: #8d8d8d;

--- a/packages/utils/theme/src/dark-theme.css
+++ b/packages/utils/theme/src/dark-theme.css
@@ -1,4 +1,5 @@
 [data-theme='dark'] {
+  --color-focus: #d1d1ff;
   --color-basic: #c2e0fa;
   --color-on-basic: #152233;
   --color-basic-hovered: #9fcef7;

--- a/packages/utils/theme/src/light-theme-more-contrast.css
+++ b/packages/utils/theme/src/light-theme-more-contrast.css
@@ -1,4 +1,5 @@
 [data-theme='light-more-contrast'] {
+  --color-focus: #00f;
   --color-basic: #484848;
   --color-on-basic: #f9f9f9;
   --color-basic-hovered: #5e5e5e;

--- a/packages/utils/theme/src/light-theme.css
+++ b/packages/utils/theme/src/light-theme.css
@@ -1,5 +1,5 @@
 [data-theme='light'] {
-  --color-blue: #00f;
+  --color-focus: #00f;
   --color-basic: #094171;
   --color-on-basic: #ffffff;
   --color-basic-hovered: #0c5291;

--- a/packages/utils/theme/src/theme.css
+++ b/packages/utils/theme/src/theme.css
@@ -40,7 +40,7 @@
   --font-weight-semi-bold: 600;
   --font-weight-bold: 700;
 
-  --color-blue: #00f;
+  --color-focus: #00f;
   --color-basic: #094171;
   --color-on-basic: #ffffff;
   --color-basic-hovered: #0c5291;

--- a/packages/utils/theme/src/utilities.css
+++ b/packages/utils/theme/src/utilities.css
@@ -132,14 +132,14 @@
 }
 
 @utility u-outline {
-  outline-color: var(--color-blue);
+  outline-color: var(--color-focus);
   outline-style: solid;
   outline-width: 2px;
   outline-offset: 2px;
 }
 
 @utility u-outline-inset {
-  outline-color: var(--color-blue);
+  outline-color: var(--color-focus);
   outline-style: solid;
   outline-width: 2px;
   outline-offset: calc(2px * -1);


### PR DESCRIPTION
### Description, Motivation and Context

Keyboard focus was mostly using `--color-blue`, expect on the following components: `Stepper, Input, Textarea, Select, Dropdown, Combobox`. For a more cohesive navigation we decided to update them to the same outline color as other components.


### Types of changes
- [x] 💄 Styles
