### PR TITLE
fix(components): align chars count to top

### DIFF
--- a/packages/components/src/form-field/FormField.stories.tsx
+++ b/packages/components/src/form-field/FormField.stories.tsx
@@ -188,16 +188,12 @@ export const CharactersCount: StoryFn = () => {
         )}
       </FormField.Control>
 
-      <div className="gap-md flex justify-between">
-        <FormField.CharactersCount
-          value={value}
-          maxLength={MAX_LENGTH}
-          description={`You can enter up to ${MAX_LENGTH} characters`}
-          liveAnnouncement={({ remainingChars }) =>
-            `You have ${remainingChars} characters remaining`
-          }
-        />
-      </div>
+      <FormField.CharactersCount
+        value={value}
+        maxLength={MAX_LENGTH}
+        description={`You can enter up to ${MAX_LENGTH} characters`}
+        liveAnnouncement={({ remainingChars }) => `You have ${remainingChars} characters remaining`}
+      />
     </FormField>
   )
 }

--- a/packages/components/src/form-field/FormFieldCharactersCount.tsx
+++ b/packages/components/src/form-field/FormFieldCharactersCount.tsx
@@ -46,7 +46,7 @@ export const FormFieldCharactersCount = ({
   }, [value])
 
   return (
-    <span className="ml-auto self-end">
+    <span className="ml-auto self-start">
       {description && (
         <FormFieldMessage className="default:sr-only">{description}</FormFieldMessage>
       )}


### PR DESCRIPTION
### Description, Motivation and Context

`FormField.CharactersCount` is supposed to be aligned to the top, not to the bottom (according to specs)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] 💄 Styles
