### PR TITLE
feat(components): tag shapes and sizes

### DIFF
--- a/packages/components/src/tag/Tag.doc.mdx
+++ b/packages/components/src/tag/Tag.doc.mdx
@@ -31,7 +31,7 @@ export default () => <Tag />;
 
 ### Design
 
-Use `design` prop to set the different look and feels of a tag.
+Use `design` prop to set the different look and feels of a tag. Default: `filled`.
 
 <Canvas of={TagStories.Design} />
 
@@ -43,9 +43,27 @@ Compose the content of the tag using the `Icon` component to add an icon to the 
 
 ### Intent
 
-Use `intent` prop to set the color intent of a tag.
+Use `intent` prop to set the color intent of a tag. Default: `basic`.
 
 <Canvas of={TagStories.Intent} />
+
+### Sizes
+
+Use `size` prop to set the different sizes of a tag. Default: `md`.
+
+<Canvas of={TagStories.Sizes} />
+
+### Shapes
+
+Use `shape` prop to set the different border radius styles of a tag. Default: `pill`.
+
+<Canvas of={TagStories.Shapes} />
+
+### All Combinations
+
+Explore all possible combinations of design, intent, shape, and size props.
+
+<Canvas of={TagStories.AllCombinations} />
 
 ## API Reference
 

--- a/packages/components/src/tag/Tag.stories.tsx
+++ b/packages/components/src/tag/Tag.stories.tsx
@@ -88,3 +88,99 @@ export const Icons: StoryFn = _args => (
     </Tag>
   </div>
 )
+
+export const Sizes: StoryFn = _args => (
+  <div className="gap-md flex flex-row items-center">
+    <Tag size="md">Medium tag</Tag>
+    <Tag size="lg">Large tag</Tag>
+  </div>
+)
+
+export const Shapes: StoryFn = _args => (
+  <div className="gap-md flex flex-row items-center">
+    <Tag shape="square">Square tag</Tag>
+    <Tag shape="rounded">Rounded tag</Tag>
+    <Tag shape="pill">Pill tag</Tag>
+    <Tag shape="rounded" className="rounded-bl-none">
+      Custom shape
+    </Tag>
+  </div>
+)
+
+export const AllCombinations: StoryFn = _args => {
+  const designs: TagProps['design'][] = ['filled', 'outlined', 'tinted']
+  const intents: TagProps['intent'][] = [
+    'main',
+    'support',
+    'accent',
+    'basic',
+    'success',
+    'alert',
+    'danger',
+    'info',
+    'neutral',
+    'surface',
+  ]
+  const shapes: TagProps['shape'][] = ['square', 'rounded', 'pill']
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="border-sm border-outline border-collapse">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="border-outline p-lg border-sm text-left font-bold">Intent/Design</th>
+            {designs.map(design => (
+              <th
+                key={design}
+                className="border-outline p-lg border-sm text-center font-bold capitalize"
+              >
+                {design}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {intents.map(intent => (
+            <tr key={intent}>
+              <td className="border-outline p-lg border-sm font-bold capitalize">{intent}</td>
+              {designs.map(design => {
+                // Skip surface intent for outlined and tinted designs
+                if (design !== 'filled' && intent === 'surface') {
+                  return (
+                    <td
+                      key={design}
+                      className="border-outline p-lg border-sm text-center text-gray-500"
+                    >
+                      N/A
+                    </td>
+                  )
+                }
+
+                return (
+                  <td key={design} className="p-lg border-sm border-outline">
+                    <div className="gap-md flex flex-wrap justify-center">
+                      {shapes.map(shape => (
+                        <Tag key={shape} design={design} intent={intent as any} shape={shape}>
+                          {shape}
+                        </Tag>
+                      ))}
+                      <Tag
+                        key="custom"
+                        design={design}
+                        intent={intent as any}
+                        shape="rounded"
+                        className="rounded-bl-none"
+                      >
+                        custom
+                      </Tag>
+                    </div>
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -7,8 +7,7 @@ export const tagStyles = cva(
   [
     'box-border inline-flex items-center justify-center gap-sm whitespace-nowrap',
     'text-caption font-bold',
-    'h-sz-20 px-md',
-    'rounded-full',
+    'px-md',
   ],
   {
     variants: {
@@ -22,6 +21,15 @@ export const tagStyles = cva(
         filled: [],
         outlined: ['border-sm', 'border-current'],
         tinted: [],
+      }),
+      size: makeVariants<'size', ['md', 'lg']>({
+        md: ['h-sz-20'],
+        lg: ['h-sz-24'],
+      }),
+      shape: makeVariants<'shape', ['square', 'rounded', 'pill']>({
+        square: [],
+        rounded: ['rounded-md'],
+        pill: ['rounded-full'],
       }),
       /**
        * Color scheme of the tag.
@@ -57,6 +65,8 @@ export const tagStyles = cva(
     defaultVariants: {
       design: 'filled',
       intent: 'basic',
+      size: 'md',
+      shape: 'pill',
     },
   }
 )

--- a/packages/components/src/tag/Tag.tsx
+++ b/packages/components/src/tag/Tag.tsx
@@ -31,6 +31,8 @@ export type TagProps = BaseTagProps & ValidTagDesignIntent
 export const Tag = ({
   design = 'filled',
   intent = 'basic',
+  size = 'md',
+  shape = 'pill',
   asChild,
   className,
   ref,
@@ -46,6 +48,8 @@ export const Tag = ({
         className,
         design,
         intent,
+        size,
+        shape,
       })}
       {...others}
     />

--- a/packages/components/src/tag/variants/default.ts
+++ b/packages/components/src/tag/variants/default.ts
@@ -1,1 +1,0 @@
-export const tw = <T>(a: T): T => a

--- a/packages/components/src/tag/variants/filled.ts
+++ b/packages/components/src/tag/variants/filled.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const filledVariants = [
   {

--- a/packages/components/src/tag/variants/outlined.ts
+++ b/packages/components/src/tag/variants/outlined.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const outlinedVariants = [
   {

--- a/packages/components/src/tag/variants/tinted.ts
+++ b/packages/components/src/tag/variants/tinted.ts
@@ -1,4 +1,4 @@
-import { tw } from './default'
+import { tw } from '@spark-ui/internal-utils'
 
 export const tintedVariants = [
   {


### PR DESCRIPTION
### Description, Motivation and Context

- Added `size` prop.
- `md` size (default) is 20px.
- `lg` size (new) is 24px.
- Added custom example for shape (`rounded-no-bl`)

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💄 Styles

### Screenshots - Animations
<img width="967" height="199" alt="Capture d’écran 2025-07-28 à 22 43 50" src="https://github.com/user-attachments/assets/f9d24004-4de6-48e5-84de-d234a0b77cd5" />

<img width="973" height="661" alt="Capture d’écran 2025-07-29 à 11 55 11" src="https://github.com/user-attachments/assets/b1dfb8b5-0c42-4107-8433-7862ae5fa742" />

