### PR TITLE
feat(components): maxDots on carousel

### DIFF
--- a/packages/components/src/carousel/Carousel.doc.mdx
+++ b/packages/components/src/carousel/Carousel.doc.mdx
@@ -135,6 +135,15 @@ The `unstyled` prop of `Carousel.PageIndicator` allows you to use your own style
 
 <Canvas of={stories.CustomPageIndicators} />
 
+
+### Maximum number of page indicators
+
+Set the `maxDots` prop of `Carousel` to customize the maximum number of page indicators. Default is `5` (must be an odd number).
+
+This may be useful on smaller screens/containers to avoid having too many page indicators.
+
+<Canvas of={stories.MaxDots} />
+
 ## API Reference
 
 <ArgTypes

--- a/packages/components/src/carousel/Carousel.stories.tsx
+++ b/packages/components/src/carousel/Carousel.stories.tsx
@@ -5,6 +5,7 @@ import { memo, useState } from 'react'
 
 import { Button } from '../button'
 import { FormField } from '../form-field'
+import { RadioGroup } from '../radio-group'
 import { Select } from '../select'
 import { Slider } from '../slider'
 import { Stepper } from '../stepper'
@@ -675,6 +676,59 @@ export const CustomPageIndicators: StoryFn = () => {
                 </Carousel.PageIndicator>
               )
             })
+          }
+        </Carousel.PagePicker>
+      </Carousel>
+    </div>
+  )
+}
+
+export const MaxDots: StoryFn = () => {
+  const [maxDots, setMaxDots] = useState<number>(5)
+
+  const handleMaxDotsChange = (value: string) => {
+    setMaxDots(value === 'Infinity' ? Infinity : Number(value))
+  }
+
+  return (
+    <div className="gap-xl flex flex-col">
+      <RadioGroup
+        value={maxDots === Infinity ? 'Infinity' : maxDots.toString()}
+        onValueChange={handleMaxDotsChange}
+        orientation="horizontal"
+        aria-label="Max dots selection"
+      >
+        <RadioGroup.Radio value="5">5</RadioGroup.Radio>
+        <RadioGroup.Radio value="7">7</RadioGroup.Radio>
+        <RadioGroup.Radio value="Infinity">Infinity</RadioGroup.Radio>
+      </RadioGroup>
+
+      <Carousel aria-label="Best products" maxDots={maxDots}>
+        <Carousel.Viewport>
+          <Carousel.Slides>
+            {Array.from({ length: 11 }).map((_, i) => (
+              <Carousel.Slide key={i} aria-label={`Slide ${i}`} className="flex items-center">
+                <RandomImage imgHeight={600} imgWidth={600} className="h-sz-256 object-cover" />
+
+                <Button className="bottom-lg right-lg absolute">Read article</Button>
+              </Carousel.Slide>
+            ))}
+          </Carousel.Slides>
+          <Carousel.Controls>
+            <Carousel.PrevButton aria-label="Previous group of items" />
+            <Carousel.NextButton aria-label="Next group of items" />
+          </Carousel.Controls>
+        </Carousel.Viewport>
+
+        <Carousel.PagePicker>
+          {({ pages }) =>
+            pages.map(page => (
+              <Carousel.PageIndicator
+                key={page}
+                index={page}
+                aria-label={`Go to page ${page + 1}`}
+              />
+            ))
           }
         </Carousel.PagePicker>
       </Carousel>

--- a/packages/components/src/carousel/Carousel.test.tsx
+++ b/packages/components/src/carousel/Carousel.test.tsx
@@ -64,4 +64,46 @@ describe('Carousel', () => {
     expect(nextButton).toBeInTheDocument()
     expect(pagePicker).toBeInTheDocument()
   })
+
+  it('should use maxDots from context', () => {
+    render(
+      <Carousel maxDots={7}>
+        <Carousel.Viewport>
+          <Carousel.Slides>
+            <Carousel.Slide className="flex items-center">
+              <button type="button">Read article 1</button>
+            </Carousel.Slide>
+            <Carousel.Slide className="flex items-center">
+              <button type="button">Read article 2</button>
+            </Carousel.Slide>
+            <Carousel.Slide className="flex items-center">
+              <button type="button">Read article 3</button>
+            </Carousel.Slide>
+          </Carousel.Slides>
+          <Carousel.Controls>
+            <Carousel.PrevButton aria-label="Next group of items" />
+            <Carousel.NextButton aria-label="Previous group of items" />
+          </Carousel.Controls>
+        </Carousel.Viewport>
+
+        <Carousel.PagePicker>
+          {({ pages, maxDots }) => {
+            // Verify that maxDots is available in the context
+            expect(maxDots).toBe(7)
+
+            return pages.map(page => (
+              <Carousel.PageIndicator
+                key={page}
+                index={page}
+                aria-label={`Go to page ${page + 1}`}
+              />
+            ))
+          }}
+        </Carousel.PagePicker>
+      </Carousel>
+    )
+
+    const carousel = screen.getByRole('region')
+    expect(carousel).toBeInTheDocument()
+  })
 })

--- a/packages/components/src/carousel/Carousel.tsx
+++ b/packages/components/src/carousel/Carousel.tsx
@@ -25,6 +25,7 @@ export const Carousel = ({
   defaultPage,
   page,
   onPageChange,
+  maxDots = 5,
   ...props
 }: Props) => {
   const carouselApi = useCarousel({
@@ -39,6 +40,7 @@ export const Carousel = ({
     page,
     pagePickerInset,
     onPageChange,
+    maxDots,
   })
 
   return (

--- a/packages/components/src/carousel/CarouselPageIndicator.tsx
+++ b/packages/components/src/carousel/CarouselPageIndicator.tsx
@@ -30,32 +30,29 @@ export const CarouselPageIndicator = ({
     }
   })
 
-  const styles = cx(
-    'group h-sz-16 relative flex',
-    'hover:cursor-pointer',
-    'w-sz-16 data-[state=active]:w-sz-44'
-  )
-
-  const dotsStyles = cx(
-    'before:rounded-sm before:block before:size-md',
-    'before:absolute before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/2',
-    'data-[state=active]:before:w-sz-32',
-    intent === 'surface'
-      ? 'data-[state=active]:before:bg-surface data-[state=inactive]:before:bg-surface/dim-2'
-      : 'data-[state=active]:before:bg-basic data-[state=inactive]:before:bg-on-surface/dim-2'
-  )
+  const indicatorProps = ctx.getIndicatorProps({ index })
 
   return (
     <button
       data-spark-component="carousel-page-indicator"
       ref={ref}
       key={index}
-      {...ctx.getIndicatorProps({ index })}
+      {...indicatorProps}
       aria-label={ariaLabel}
       className={cx(
         {
-          [styles]: !unstyled,
-          [dotsStyles]: !unstyled,
+          [cx(
+            'border-outline group relative flex justify-center border-0 hover:cursor-pointer',
+            'm-sm rounded-sm transition-all duration-[200ms] ease-linear',
+            'w-sz-8 h-sz-8',
+            'data-[state=active]:w-sz-32 data-[state=active]:h-sz-8',
+            'data-[state=edge]:w-sz-4 data-[state=edge]:h-sz-4',
+            'data-[state=hidden]:size-0',
+            intent === 'surface'
+              ? 'data-[state=active]:bg-surface bg-surface/dim-2'
+              : 'data-[state=active]:bg-basic bg-on-surface/dim-2'
+          )]: !unstyled,
+          // [dotsStyles]: !unstyled,
         },
         className
       )}

--- a/packages/components/src/carousel/CarouselPagePicker.tsx
+++ b/packages/components/src/carousel/CarouselPagePicker.tsx
@@ -22,7 +22,8 @@ export const CarouselPagePicker = ({ children, className }: Props) => {
         data-spark-component="carousel-page-picker"
         {...ctx.getIndicatorGroupProps()}
         className={cx(
-          'default:min-h-sz-16 flex w-full flex-wrap items-center justify-center',
+          'flex-wrap items-center justify-center',
+          'default:min-h-sz-16 flex',
           ctx.pagePickerInset && 'bottom-sz-12 absolute inset-x-0',
           className
         )}

--- a/packages/components/src/carousel/types.ts
+++ b/packages/components/src/carousel/types.ts
@@ -47,6 +47,10 @@ export interface UseCarouselProps {
   scrollBehavior?: 'instant' | 'smooth'
   onPageChange?: (pageIndex: number) => void
   pagePickerInset?: boolean
+  /**
+   * Maximum number of dots to display in the page picker.
+   */
+  maxDots?: number
 }
 
 export interface ComputedRootProps {
@@ -123,7 +127,7 @@ export interface ComputedIndicatorProps {
   'data-part': 'indicator'
   'data-orientation': 'horizontal'
   'data-index': number
-  'data-state': 'active' | 'inactive'
+  'data-state': 'active' | 'edge' | 'hidden' | 'idle'
   tabIndex: 0 | -1
   onClick: () => void
   onKeyDown: (event: KeyboardEvent) => void
@@ -159,4 +163,5 @@ export interface CarouselAPI extends AnatomyPropsSetters {
   snapType: UseCarouselProps['snapType']
   snapStop: UseCarouselProps['snapStop']
   scrollBehavior: UseCarouselProps['scrollBehavior']
+  maxDots: number
 }

--- a/packages/components/src/carousel/useCarousel.ts
+++ b/packages/components/src/carousel/useCarousel.ts
@@ -24,7 +24,7 @@ import { useEvent } from './useEvent'
 import { useIsMounted } from './useIsMounted'
 import { useScrollEnd } from './useScrollEnd'
 import { useSnapPoints } from './useSnapPoints'
-import { getSnapPositions, isSnapPoint } from './utils'
+import { computeDotState, getSnapPositions, isSnapPoint } from './utils'
 
 const DATA_SCOPE = 'carousel' as const
 const DIRECTION = 'ltr' as const
@@ -40,6 +40,7 @@ export const useCarousel = ({
   scrollBehavior = 'smooth',
   loop = false,
   pagePickerInset = false,
+  maxDots = 5,
   // state control
   page: controlledPage,
   onPageChange: onPageChangeProp,
@@ -172,6 +173,7 @@ export const useCarousel = ({
     scrollBehavior,
     loop,
     pagePickerInset,
+    maxDots,
     // computed state
     page: pageState,
     pageSnapPoints,
@@ -289,18 +291,23 @@ export const useCarousel = ({
     }),
 
     getIndicatorProps: ({ index }): ComputedIndicatorProps => {
-      const isActivePage = index === pageState
+      const dotState = computeDotState({
+        dotIndex: index,
+        pageState,
+        totalPages: pageSnapPoints.length,
+        maxDots,
+      })
 
       return {
         role: 'radio',
         id: `carousel::${carouselId}::indicator:${index}`,
-        'aria-checked': isActivePage,
+        'aria-checked': index === pageState,
         'data-scope': DATA_SCOPE,
         'data-part': 'indicator',
         'data-orientation': 'horizontal',
         'data-index': index,
-        'data-state': isActivePage ? 'active' : 'inactive',
-        tabIndex: isActivePage ? 0 : -1,
+        'data-state': dotState,
+        tabIndex: index === pageState ? 0 : -1,
         onClick: () => {
           scrollTo(index, scrollBehavior)
         },

--- a/packages/components/src/carousel/utils.ts
+++ b/packages/components/src/carousel/utils.ts
@@ -76,3 +76,47 @@ export function getSnapPositions({
     })
     .map(slide => (slide as HTMLElement).offsetLeft)
 }
+
+/**
+ * Calculate the state of a dot indicator of a carousel depending on the current page and the total number of pages.
+ */
+export function computeDotState({
+  dotIndex,
+  pageState,
+  totalPages,
+  maxDots = 5,
+}: {
+  dotIndex: number
+  pageState: number
+  totalPages: number
+  maxDots?: number
+}): 'active' | 'edge' | 'idle' | 'hidden' {
+  if (totalPages <= maxDots) {
+    return dotIndex === pageState ? 'active' : 'idle'
+  }
+
+  if (pageState <= Math.floor(maxDots / 2)) {
+    if (dotIndex > maxDots - 1) return 'hidden'
+    if (dotIndex === pageState) return 'active'
+    if (dotIndex === maxDots - 1) return 'edge'
+
+    return 'idle'
+  }
+
+  if (pageState >= totalPages - Math.ceil(maxDots / 2)) {
+    const startIndex = totalPages - maxDots
+    if (dotIndex < startIndex) return 'hidden'
+    if (dotIndex === pageState) return 'active'
+    if (dotIndex === startIndex) return 'edge'
+
+    return 'idle'
+  }
+
+  const startIndex = pageState - Math.floor(maxDots / 2)
+  const endIndex = pageState + Math.floor(maxDots / 2)
+  if (dotIndex < startIndex || dotIndex > endIndex) return 'hidden'
+  if (dotIndex === pageState) return 'active'
+  if (dotIndex === startIndex || dotIndex === endIndex) return 'edge'
+
+  return 'idle'
+}

--- a/packages/components/src/dialog/Dialog.stories.tsx
+++ b/packages/components/src/dialog/Dialog.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../button'
 import { FormField } from '../form-field'
 import { Input } from '../input'
 import { RadioGroup } from '../radio-group'
+import { Tabs } from '../tabs'
 import { Dialog, type DialogContentProps } from '.'
 
 const meta: Meta<typeof Dialog> = {
@@ -32,17 +33,25 @@ export const Default: StoryFn = () => {
       <Dialog.Portal>
         <Dialog.Overlay />
 
-        <Dialog.Content size="sm">
+        <Dialog.Content size="lg">
           <Dialog.Header>
-            <Dialog.Title>Edit profile</Dialog.Title>
+            <Dialog.Title>Accessibilité</Dialog.Title>
           </Dialog.Header>
 
           <Dialog.Body>
-            <Dialog.Description>
-              Make changes to your profile here. Click save when you are done.
-            </Dialog.Description>
+            <Tabs defaultValue="tab1">
+              <Tabs.List aria-labelledby="tasks-label">
+                <Tabs.Trigger value="settings">Paramètres</Tabs.Trigger>
+                <Tabs.Trigger value="information">Informations</Tabs.Trigger>
+              </Tabs.List>
 
-            <p>Lorem ipsum dolor sit amet</p>
+              <Tabs.Content value="settings">
+                <p>Paramètre d'accessibilité</p>
+              </Tabs.Content>
+              <Tabs.Content value="information">
+                <p>Informations</p>
+              </Tabs.Content>
+            </Tabs>
           </Dialog.Body>
 
           <Dialog.Footer className="gap-md flex justify-end">


### PR DESCRIPTION
<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [LBCSPARK-370](https://jira.ets.mpi-internal.com/browse/LBCSPARK-370)

### Description, Motivation and Context

New prop for `Carousel`: `maxDots` (default: 5).

set to `Infinity` (number) to display all page indicators (dots). DOES NOT WORK if you use custom page indicators (you will have access to the `data-state` attribute to style it yourself)
 
### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
- [x] 💄 Styles

### Screenshots - Animations

https://github.com/user-attachments/assets/4f03f734-6d24-404a-a507-17e516ef8535


