### PR TITLE
fix(theme-utils): improved surface hover color token

### DIFF
--- a/packages/utils/theme/src/dark-theme.css
+++ b/packages/utils/theme/src/dark-theme.css
@@ -69,7 +69,7 @@
   --color-on-background-variant: #f6f8f9;
   --color-surface: #202730;
   --color-on-surface: #f6f8f9;
-  --color-surface-hovered: #000000;
+  --color-surface-hovered: #2b3441;
   --color-surface-inverse: #f6f8f9;
   --color-on-surface-inverse: #2b3441;
   --color-surface-inverse-hovered: #f0f2f5;


### PR DESCRIPTION
### Description, Motivation and Context

Contrast effect of `surface-hovered` was too strong in dark mode theme.

### Types of changes
- [x] 💄 Styles