### PR TITLE
ci: explicit node version for vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,9 @@
   "namespaces": [
     "spark-ui"
   ],
+  "engines": {
+    "node": "22.x"
+  },
   "config": {
     "commitizen": {
       "path": "@commitlint/cz-commitlint"


### PR DESCRIPTION
node 18 is currently used and will be deprecated on September 1st

<!-- https://github.com/leboncoin/spark-web/issues -->
**TASK**: [LBCSPARK-415](https://jira.ets.mpi-internal.com/browse/LBCSPARK-415)

### Description, Motivation and Context

Node 18 is used by our Vercel config and will stop working very soon. Upgrading to Node 22.

Refer to Vercel statement on the matter: https://vercel.com/changelog/node-js-18-is-being-deprecated

### Types of changes
- [x] 🛠️ Tool


### Screenshots - Animations

<img width="1544" height="673" alt="Capture d’écran 2025-08-08 à 14 57 03" src="https://github.com/user-attachments/assets/09ddf236-237c-4c75-b5c8-8f4bcfee12be" />

