### PR TITLE
fix(components): ts error was omitting usage of onValueChange on the …

### DIFF
--- a/packages/components/src/textarea/Textarea.tsx
+++ b/packages/components/src/textarea/Textarea.tsx
@@ -1,13 +1,13 @@
 import { cx } from 'class-variance-authority'
-import { ComponentPropsWithRef, PropsWithChildren } from 'react'
+import { ComponentPropsWithoutRef, PropsWithChildren, Ref } from 'react'
 
-import { Input } from '../input'
+import { Input, InputProps } from '../input'
 
-export interface TextareaProps extends ComponentPropsWithRef<'textarea'> {
-  /**
-   * If `false`, the textarea won't be resizable.
-   */
+type TextareaPrimitiveProps = ComponentPropsWithoutRef<'textarea'>
+
+export interface TextareaProps extends TextareaPrimitiveProps, Pick<InputProps, 'onValueChange'> {
   isResizable?: boolean
+  ref?: Ref<HTMLTextAreaElement>
 }
 
 const Root = ({

--- a/packages/components/src/textarea/TextareaGroup.tsx
+++ b/packages/components/src/textarea/TextareaGroup.tsx
@@ -1,8 +1,8 @@
 import { InputGroup, InputGroupProps } from '../input'
 
-export type TextareaGroupProps = Omit<InputGroupProps, 'onClear'>
+export type TextareaGroupProps = InputGroupProps
 
-export const TextareaGroup = (props: InputGroupProps) => {
+export const TextareaGroup = (props: TextareaGroupProps) => {
   return <InputGroup {...props} />
 }
 


### PR DESCRIPTION
### Description, Motivation and Context

Two bugs are fixed:

1. TS issue forbidding the use of `onValueChange` on `Textarea` (users had to resort on `onChange`)
2. Omitting `onClear` prop on `TextareaGroup` (the clear button feature has been added 4 months ago, this `Omit` should have been removed at the same time)

### Types of changes
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
