### PR TITLE
Improve shadow tokens

### DIFF
--- a/documentation/helpers/TokenPreview/index.tsx
+++ b/documentation/helpers/TokenPreview/index.tsx
@@ -24,6 +24,14 @@ export const ColorPreview = ({ bg }: { bg: string }) => {
   )
 }
 
+export const ShadowsPreview = () => {
+  return (
+    <div>
+      <div className="size-sz-144 shadow-xs" />
+    </div>
+  )
+}
+
 export const BackgroundColorPreview = () => {
   const bgColors = {
     'bg-main': {

--- a/documentation/helpers/TokenPreview/index.tsx
+++ b/documentation/helpers/TokenPreview/index.tsx
@@ -24,14 +24,6 @@ export const ColorPreview = ({ bg }: { bg: string }) => {
   )
 }
 
-export const ShadowsPreview = () => {
-  return (
-    <div>
-      <div className="size-sz-144 shadow-xs" />
-    </div>
-  )
-}
-
 export const BackgroundColorPreview = () => {
   const bgColors = {
     'bg-main': {

--- a/documentation/styling/Tokens.mdx
+++ b/documentation/styling/Tokens.mdx
@@ -12,7 +12,7 @@ import { RadioGroup } from '@spark-ui/components/radio-group'
 import { VisuallyHidden } from '@spark-ui/components/visually-hidden'
 import { cx } from 'class-variance-authority'
 import Xarrow, { Xwrapper } from "react-xarrows";
-import { getCssVariable, getComputedCssVariable, BackgroundColorPreview, TextColorPreview, OutlineColorPreview, ShadowsPreview } from '@docs/helpers/TokenPreview'
+import { getCssVariable, getComputedCssVariable, BackgroundColorPreview, TextColorPreview, OutlineColorPreview } from '@docs/helpers/TokenPreview'
 
 <Meta title="Styling/Design Tokens" />
 
@@ -234,21 +234,129 @@ Colors to use for overlays (ex: modals, tooltips, dropdowns). Combine it with `d
 <div className="bg-overlay/dim-3" />
 ```
 
-### Preview - Backgrounds
+### Backgrounds
 
 <BackgroundColorPreview />
 
-### Preview - Shadows
 
-<ShadowsPreview />
-
-### Preview - Text
+### Text
 
 <TextColorPreview />
 
-### Preview - Outlines
+### Outlines
 
 <OutlineColorPreview />
+
+## Shadows
+
+### Regular shadows
+
+Use utilities like `shadow-xs` and `shadow-sm` to apply a box shadow to an element. You can prefix it with `inset-` to apply it to the inside of the element.
+
+You can also have both an inset and a regular shadow at once.
+
+<div className='sb-unstyled'>
+    <div className='flex gap-lg flex-wrap'>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-xs</Tag>
+            <div className="size-sz-64 shadow-xs" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-sm</Tag>
+            <div className="size-sz-64 shadow-sm" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-md</Tag>
+            <div className="size-sz-64 shadow-md" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-lg</Tag>
+            <div className="size-sz-64 shadow-lg" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-xl</Tag>
+            <div className="size-sz-64 shadow-xl" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-xs</Tag>
+            <div className="size-sz-64 inset-shadow-xs" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-sm</Tag>
+            <div className="size-sz-64 inset-shadow-sm" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-md</Tag>
+            <div className="size-sz-64 inset-shadow-md" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-lg</Tag>
+            <div className="size-sz-64 inset-shadow-lg" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-xl</Tag>
+            <div className="size-sz-64 inset-shadow-xl" />
+        </div>
+    </div>
+</div>
+
+### Ring shadows
+
+Use utilities like `ring-2` and `ring-4` to apply a solid box-shadow to an element. You can prefix it with `inset-` to apply it to the inside of the element.
+
+You can combine a ring with a shadow to create a more complex effect. You can also have both an inset and a regular ring at once.
+
+<div className='sb-unstyled'>
+    <div className='flex gap-lg flex-wrap'>
+    <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>ring-1</Tag>
+            <div className="size-sz-64 ring-1" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>ring-2</Tag>
+            <div className="size-sz-64 ring-2" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>ring-4</Tag>
+            <div className="size-sz-64 ring-4" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>ring-8</Tag>
+            <div className="size-sz-64 ring-8" />
+        </div>
+        
+    </div>
+</div>
+
+### Colored shadows
+
+Use utilities like `shadow-main` (or any other Spark color) to change the color of a box shadow. 
+
+Use utilities like `ring-main` (or any other Spark color) to change the color of a ring.
+
+<div className='sb-unstyled'>
+    <div className='flex gap-lg flex-wrap'>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>shadow-md +shadow-main</Tag>
+            <div className="size-sz-64 shadow-md shadow-main" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-shadow-md + inset-shadow-main</Tag>
+            <div className="size-sz-64 inset-shadow-md inset-shadow-main" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>ring-2 + ring-main</Tag>
+            <div className="size-sz-64 ring-2 ring-main" />
+        </div>
+        <div className='flex flex-col gap-md items-center'>
+            <Tag intent="info" design='tinted' className='self-center'>inset-ring-2 + inset-ring-main</Tag>
+            <div className="size-sz-64 inset-ring-2 inset-ring-main" />
+        </div>
+    </div>
+</div>
+
+
+
 
 ## Spacing 
 

--- a/documentation/styling/Tokens.mdx
+++ b/documentation/styling/Tokens.mdx
@@ -12,7 +12,7 @@ import { RadioGroup } from '@spark-ui/components/radio-group'
 import { VisuallyHidden } from '@spark-ui/components/visually-hidden'
 import { cx } from 'class-variance-authority'
 import Xarrow, { Xwrapper } from "react-xarrows";
-import { getCssVariable, getComputedCssVariable, BackgroundColorPreview, TextColorPreview, OutlineColorPreview } from '@docs/helpers/TokenPreview'
+import { getCssVariable, getComputedCssVariable, BackgroundColorPreview, TextColorPreview, OutlineColorPreview, ShadowsPreview } from '@docs/helpers/TokenPreview'
 
 <Meta title="Styling/Design Tokens" />
 
@@ -237,6 +237,10 @@ Colors to use for overlays (ex: modals, tooltips, dropdowns). Combine it with `d
 ### Preview - Backgrounds
 
 <BackgroundColorPreview />
+
+### Preview - Shadows
+
+<ShadowsPreview />
 
 ### Preview - Text
 

--- a/packages/utils/theme/src/theme.css
+++ b/packages/utils/theme/src/theme.css
@@ -140,6 +140,12 @@
   --shadow-md: 0 6px 12px 0 var(--color-shadow);
   --shadow-lg: 0 8px 16px 0 var(--color-shadow);
   --shadow-xl: 0 12px 24px 0 var(--color-shadow);
+
+  --inset-shadow-xs: inset 0 1px 2px 0 var(--color-shadow);
+  --inset-shadow-sm: inset 0 4px 8px 0 var(--color-shadow);
+  --inset-shadow-md: inset 0 6px 12px 0 var(--color-shadow);
+  --inset-shadow-lg: inset 0 8px 16px 0 var(--color-shadow);
+  --inset-shadow-xl: inset 0 12px 24px 0 var(--color-shadow);
   --shadow-none: none;
 
   --spacing-scale: 16; /* for a 16px base font size */


### PR DESCRIPTION
### Description, Motivation and Context
- Added missing `inset-*` version of the shadow tokens.
- Added tokens preview for shadows and "rings" in the Tokens page (Storybook).

### Types of changes
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧾 Documentation
