### PR TITLE
fix(components): preserve input value from ref when cloning

### DIFF
--- a/packages/components/src/input/InputGroup.tsx
+++ b/packages/components/src/input/InputGroup.tsx
@@ -135,6 +135,11 @@ export const InputGroup = ({
     onClearRef.current = onClear
   }, [onClear])
 
+  // Preserve the input value when cloning. Some libraries like React Hook Form
+  // only expose a ref (via `register`) without direct value access, so we need
+  // to manually retrieve the value from the ref to avoid losing it.
+  const inputRefValue = inputRef.current?.value
+
   return (
     <InputGroupContext.Provider value={current}>
       <div
@@ -148,9 +153,9 @@ export const InputGroup = ({
         <div className="relative inline-flex w-full">
           {input &&
             cloneElement(input, {
+              value: value ?? inputRefValue ?? '',
               ref,
               defaultValue: undefined,
-              value: value ?? '',
               onChange: handleChange,
             })}
 


### PR DESCRIPTION
## (components): InputGroup


### Description, Motivation and Context
When cloning the input element, the current value was getting lost in scenarios where libraries like **React Hook Form** only expose a `ref` (via the ⁠[register](https://react-hook-form.com/docs/useform/register) method) without providing direct access to the input value.

## Solution
Retrieve the current value from ⁠inputRef.current?.value before cloning the input to ensure the value is preserved and passed correctly.


### Types of changes
- [ ] 🛠️ Tool
- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles
