### PR TITLE
feat(components): adding support to ai intent for tag comp

### DIFF
--- a/packages/components/src/tag/Tag.stories.tsx
+++ b/packages/components/src/tag/Tag.stories.tsx
@@ -25,6 +25,7 @@ const intents: TagProps['intent'][] = [
   'info',
   'neutral',
   'surface',
+  'ai',
 ]
 const designs: TagProps['design'][] = ['filled', 'outlined', 'tinted']
 
@@ -45,7 +46,10 @@ export const Intent: StoryFn = _args => (
     {designs.map(design => (
       <div key={design} className="gap-md flex flex-row">
         {intents.map(intent => {
-          if (design !== 'filled' && intent === 'surface') {
+          if (
+            (design !== 'filled' && intent === 'surface') ||
+            (design !== 'tinted' && intent === 'ai')
+          ) {
             return (
               <span key={intent} className="text-small self-center">
                 N/A
@@ -100,6 +104,7 @@ export const AllCombinations: StoryFn = _args => {
     'info',
     'neutral',
     'surface',
+    'ai',
   ]
   const shapes: TagProps['shape'][] = ['rounded']
 
@@ -125,7 +130,10 @@ export const AllCombinations: StoryFn = _args => {
               <td className="border-outline p-lg border-sm font-bold capitalize">{intent}</td>
               {designs.map(design => {
                 // Skip surface intent for outlined and tinted designs
-                if (design !== 'filled' && intent === 'surface') {
+                if (
+                  (design !== 'filled' && intent === 'surface') ||
+                  (design !== 'tinted' && intent === 'ai')
+                ) {
                   return (
                     <td
                       key={design}

--- a/packages/components/src/tag/Tag.styles.tsx
+++ b/packages/components/src/tag/Tag.styles.tsx
@@ -36,7 +36,18 @@ export const tagStyles = cva(
        */
       intent: makeVariants<
         'intent',
-        ['main', 'support', 'accent', 'success', 'alert', 'info', 'neutral', 'danger', 'surface']
+        [
+          'main',
+          'support',
+          'accent',
+          'success',
+          'alert',
+          'info',
+          'neutral',
+          'danger',
+          'surface',
+          'ai',
+        ]
       >({
         main: [],
         support: [],
@@ -47,6 +58,7 @@ export const tagStyles = cva(
         info: [],
         neutral: [],
         surface: [],
+        ai: [],
       }),
     },
     compoundVariants: [...filledVariants, ...outlinedVariants, ...tintedVariants],

--- a/packages/components/src/tag/variants/tinted.ts
+++ b/packages/components/src/tag/variants/tinted.ts
@@ -41,4 +41,9 @@ export const tintedVariants = [
     design: 'tinted',
     class: tw(['bg-neutral-container', 'text-on-neutral-container']),
   },
+  {
+    intent: 'ai',
+    design: 'tinted',
+    class: tw(['bg-ai-container', 'text-on-ai-container']),
+  },
 ] as const


### PR DESCRIPTION
### Description, Motivation and Context
Adding new color token support for `Tag` component.

**[update]** As discussed with Spark UI, AI variant mandatory icon and border (on tinted variant) will be handled on implementation.

### Types of changes
- [ ] 🛠️ Tool
- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [x] 💄 Styles

### Screenshots - Animations
<img width="1035" height="292" alt="image" src="https://github.com/user-attachments/assets/a20eb199-8886-40b6-bc3e-45c56cadbdff" />

